### PR TITLE
manage-groups.rst: completely overhauled

### DIFF
--- a/manage-groups.rst
+++ b/manage-groups.rst
@@ -1,48 +1,68 @@
 Groups
 ******
 
-This is the group-manage area. You can edit existing and add new groups.
+This is the group management area. You can edit existing groups and add new groups.
 
-What are groups actually?
-  Groups in Zammad are similar to working groups that deal with different topics within a company.
-  For example, The tickets relevant to the sales department are available in the 'Sales' group, while the tickets for the support department are available in the 'Support' group.
-  Tickets enter Zammad through various channels and are sorted by groups. The tickets (cases) are thus made available to the agents responsible for the group.
-  A group can be compared to a cabinet in which the folders (with cases that need to be processed) are set sorted.
-  Each agent has his / her closet for which he is responsible.
-  Several people can be responsible for processing the cases inside the cabinets and work on them. This setting can be defined for each individual user in Users Management
+What are groups?
+-----------------
 
-**group-settings**
+Groups in Zammad are similar to working groups that deal with different topics within a company. For example, the tickets relevant to the sales department might be available in the *Sales* group, while the tickets for the support department might be available in the *Support* group. These are just examples; how you structure your groups is up to you.
+  
+Tickets enter Zammad through various channels (e.g. via email) and are then sorted into these groups. The tickets (cases) are thus made available to the agents responsible for the group. Each ticket can only belong to one group, and you can decide with a permission system what permissions your agents have in each group. For example, you might want set up a group *Management* for confidential tickets; with the permission system you can configure that only a few select agents will have access to these tickets.
 
-By clicking on a group or clicking "new group" you access the edit mask. The following settings can be made here:
+For an additional way to categorize tickets, have a look at  :ref:`manage_tags`.
 
-- set or change the name
-- Assignment timeout (in minutes) --> The time after the ticket is changed to "unassigned" after the assigned agent does not work on the ticket
-- follow-up possible --> This is about the decision, what happens with a new message from the customer after a ticket has been closed. Either the status of the ticket is changed to "open" (yes) or a completely new ticket is created (no)
-- assign follow ups --> Here it is to decide whether in the case of a follow up the agent is to be registered as the owner who was saved as the last owner (yes) or whether the owner should be left open (no)
-- E-Mail --> the Email-address the group is assigned to. That means that all tickets sent to this e-mail address will be assigned to this group. Also, this email address is the sender address for e-mails written from the system.
-- signature -->  an already created signature can be selected (Channels --> E-Mail --> Signatures)
-- note --> notes are visible to agents but never to customers
-- set the group active or inactive
+Group settings
+---------------
+
+Click on a group to edit it, or click on *New group* to create a new group.
+
+There you can edit the following settings:
+
+- *Name*: choose a name for the group.
+
+- *Assignment timeout*: the time in minutes after which the ticket's state will revert back to *unassigned* after the assigned agent hasn't worked on the ticket.
+
+- *Follow up possible*: configure what happens when a customer replies to a closed ticket:
+
+  - *yes*: the ticket will be reopened.
+  - *do not reopen ticket but create new ticket*: the ticket will remain closed, and Zammad will instead put the customer's reply in a completely new ticket.
+
+- *Assign follow ups*: configure whether a closed ticket that has been reopened due to a customer reply should remain assigned to the last agent:
+
+  - *yes*: the ticket will remain to the last agent who owned it.
+  - *no*: Zammad will unassign the ticket.
+
+- *Email*: choose which email address will be used as the sending address (`From` header) when agents reply to tickets in this group. Email addresses can be configured in Channels → Email → Accounts.
+
+- *Signature*: choose which signature should be appended when agents reply to tickets in this group. Signatures can be configured in Channels → Email → Signatures.
+
+- *Note*: an internal note about the group that is only visible to people who can access the group management area.
+
+- *Active*: choose whether the group is enabled or not. Groups cannot be deleted, only set to inactive.
 
 Eventually it should look something like this:
 
 .. image:: images/manage/Zammad_Helpdesk_-_Groups.jpg
 
-The access rights for agents to a group can be set up as follows:
+Permissions
+--------------
 
-1.) directly via the user administration (Admin-Interface --> Manage --> Users), please see: :ref:`manage_user_rights`
+The group permissions for agents can be set up as follows:
+
+1. directly via the user administration (Admin → Manage → Users), please see: :ref:`manage_user_rights`
 
 or
 
-2) With the permission setting via a role (Admin-Interface --> Manage --> Role), please see: :ref:`manage_roles`
+2. With the permission setting via a role (Admin → Manage → Role), please see: :ref:`manage_roles`
 
 It is recommended to avoid using both configurations.
 
 
 
-.. Hint:: If the "Group" field does not appear in the ticket information, check whether:
+.. Hint:: If the *Group* field does not appear in the ticket view, ensure that:
 
-    * more than one group is created
-    * the current user has change-permissions to more than one group
+    * you have created more than one group
+    * the current user has change permissions to more than one group
 
-  This is because Zammad automatically hides selection fields with only one selection
+  This is necessary because Zammad automatically hides selection fields with only one option.

--- a/manage-tags.rst
+++ b/manage-tags.rst
@@ -1,3 +1,5 @@
+.. _manage_tags:
+
 Tags
 ****
 


### PR DESCRIPTION
I noticed that this part of the documentation seemed subpar during this discussion: https://community.zammad.org/t/what-does-assign-follow-ups-do/2010/2

So I went ahead and overhauled it. Someone please double check that I'm really right about the Email part :)

- Improved spelling and grammar
- Improved formatting, added proper headings
- Clarified that "Support" and "Sales" are only examples, and not fixed
- Removed the cabinet/folder analogy, IMO it was unnecessary
- Mentioned the permission system and tags in the "What are groups" section
- Clarified all options, especially:
	- Assign follow ups: clarified that "leave open" means "will be unassigned"
	- Email: removed the "That means that all tickets sent to this e-mail address will be assigned to this group", it seems completely wrong to me? AFAIK Channels -> Email -> Accounts -> Destination Group decides which email will be routed to which group. Otherwise it would also be pretty much undefined what would happen when you assign the same email address to multiple groups.
	- Note: replaced the nonsensical text
	- Active: clarified that groups cannot be deleted
- Added a Permissions heading to the section dealing with permissions
- Fixed the list in the Permissions section