### PR TITLE
manage-scheduler.rst: completely overhauled

### DIFF
--- a/manage-scheduler.rst
+++ b/manage-scheduler.rst
@@ -27,7 +27,7 @@ Add a new scheduler
 
 The scheduler shown in the screenshot would have the following effects:
 
-Every workday (Monday to Friday) at 9:00 a. m., all tickets which:
+Every workday (Monday to Friday) at 9:00 a.m. (*UTC*), all tickets which:
 
 - are not closed and
 - are assigned to the Sales group and 

--- a/manage-scheduler.rst
+++ b/manage-scheduler.rst
@@ -1,9 +1,14 @@
 Scheduler
 *********
 
-The sheduler performs time-based automated actions. Such an action may be a change of any information on the tickets.
+The scheduler performs time-based automated actions. You can set up your own schedulers, configure at which points in time they should run, set up conditions to determine which tickets they should affect, and then configure the actions that you want to be executed on these tickets.
 
-That's how it works:
+.. note:: Schedulers with *Action: Delete* are currently the only way in the Zammad front end to permanently delete tickets. This limitation is intentional as Zammad is designed to be revision-proof. A possible use case for such a scheduler is to delete spam tickets some time after creation (e.g. 30 days).
+
+.. warning:: While it is possible to delegate scheduler permissions to normal agents with the ``admin/scheduler`` permission, it is inadvisable to do so. Malicious agents could use a scheduler to access tickets in restricted groups (by moving them to a non-restricted group) or to delete arbitrary tickets.
+
+Add a new scheduler
+===================
 
 .. image:: images/manage/Zammad_Helpdesk_-_Manage-Scheduler-Steps1-3.jpg
 
@@ -11,28 +16,28 @@ That's how it works:
 
 .. image:: images/manage/Zammad_Helpdesk_-_Manage-Scheduler-step6-8.jpg
 
+1. *Name*: choose a name for the scheduler.
+2. *When should the job run*: choose the points in time when the scheduler should run.
+3. *Conditions for affected objects*: determine the ticket attributes (conditions) to limit on which tickets the actions configured in step 5 are to be performed.
+4. *Preview*: this list previews some tickets that your conditions are matching and shows a total of how many tickets are being matched. Use this to double-check the entered conditions.
+5. *Execute changes on objects*: determine the changes to be made to the ticket.
+6. *Disable notifications*: by default, actions triggered by schedulers won't send notifications. You can override this here by setting this to *no*.
+7. *Note*: you can use the note field to describe the purpose of the scheduler. This is only visible to other admins when they are editing the scheduler. It is *not* a way to add notes to tickets.
+8. *Active*: with this setting you can enable/disable the scheduler.
 
-1. Set the name
-2. Set the time when the job should run
-3. Determine the ticket attributes (conditions) to limit the tickets on which an action is to be performed
-4. Preview of the selected tickets - here you can doublecheck the entered conditions 
-5. Determine the change to be made on the ticket. It is advisable to make a note on the ticket when carrying out the action. This ensures that this step is visible to all users in the ticket.
-6. Should notifications be issued or not? (yes -> no notifications are sent / no -> notifications are sent)
-7. Insert a note to the ticket so that everyone can see what has happened in the ticket (only agents can read the note)
-8. Set the scheduler to inactive
+The scheduler shown in the screenshot would have the following effects:
 
+Every workday (Monday to Friday) at 9:00 a. m., all tickets which:
 
-**For this example, it means:**
+- are not closed and
+- are assigned to the Sales group and 
+- whose escalation was 30 minutes ago
 
-Every day (Monday to Friday) at 9:00 a. m., all tickets will be:
+will be:
 
-- assigned to the Sales group and 
-- are not closed 
-- and whose escalation was 30 minutes ago
+- assigned to Emma and
+- have their priority changed to 3 high.
 
-assigned to Emma and the priority is set to 3-high.
+As a supervisor in the Sales group, this enables Emma to intercept and process escalated tickets.
 
-As a supervisor in the Sales group, this enables you to intercept and process escalated tickets.
-
-
-.. Note:: This is currently the only place where it's possible to delete tickets via frontend (action --> delete)
+Emma will not receive notifications when the scheduler assigns her these tickets, and no note will be added to them. 


### PR DESCRIPTION
As mentioned in [this discussion](https://community.zammad.org/t/scheduler-add-note-to-ticket/1930), I'm pretty certain by now this page was plain wrong about the note field, so I've decided to overhaul it. Please double-check though if I'm really right about this :)

- Improved spelling and grammar.
- Improved formatting, added proper headings.
- Fixed the description of the note field - it doesn't add notes to the affected tickets, but only allows the admin to save a description of the scheduler.
- Added a warning that it's not safe to delegate scheduler permissions to normal agents.
- Explicitly labeled the documented fields, e.g. 1. now says "Name". That should help when searching for the field names and should improve accessibility.
- Fixed a typo that's actually in Zammad's user interface: effected -> affected. This still needs to be fixed in Zammad itself.

What still could be improved:
- I'm not sure how I feel about the screenshots with the example scheduler. The screenshot is not accessible, so visually impaired people cannot actually tell how the scheduler in the screenshot is configured. Maybe it should also be described in text, but then it would be duplicate. I've tried to add an alt text to the screenshots, but I cannot figure out how to add a multi-line alt text in RST.
- The note "something must be done about these tickets" in the screenshots stems from the original author's misunderstanding of the note field's purpose and should probably be replaced by a note that makes it clear that it only describes the scheduler.