### PR TITLE
Add hint for G-Suite users on 2 step verification

### DIFF
--- a/channels/email/accounts/2fa-gmail.rst
+++ b/channels/email/accounts/2fa-gmail.rst
@@ -29,6 +29,9 @@ before you can add your Gmail account to Zammad.
    For more information, see `Google’s official help article on the subject
    <https://support.google.com/accounts/answer/185833>`_.
 
+   .. note:: G-Suite users might not be able to activiate 2 step verification, this option then has to be 
+      enabled by your G-Suite administrator (Security → Basic settings)
+
 Step 1: Access Your App Password Settings Page
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
In some situations it's possible a user cannot activate 2 step verficiation for an account. This might be because he's missing the right to do so.

This commit provides a hint that it needs to be active and where the G-Suite admin can find the setting.