### PR TITLE
Enhance SAML documentation

### DIFF
--- a/settings/security/third-party/saml.rst
+++ b/settings/security/third-party/saml.rst
@@ -3,10 +3,13 @@ SAML
 
 It is possible to create a quick login for your helpdesk via SAML for Enterprise SSO integrations.
 
-**Prerequisites:**
+.. image:: /images/settings/security/third-party/saml/zammad_connect_saml_thirdparty.png
+   :alt: Example configuration of SAML
+
+Prerequisites:
    A working SAML Identity Provider (IdP) such as Keycloak, Redhat SSO Server, ADFS, Okta, etc.
 
-**Please Note:**
+Please Note:
    Testing has confirmed working deployment with Keycloak 7.0.0. But should also work with any standard SAML compliant IdP.
 
    Configuring the upstream SAML IdP is outside the scope of Zammad documentation.
@@ -19,59 +22,50 @@ Configure SAML in Zammad
 
 Define the fields per your upstream IdP documentation, some known working Keycloak IdP values are provided for reference.
 
-**IDP SSO target URL:**
-
-``https://keycloakFQDN/auth/realms/master/protocol/saml``
-
-.. note:: This will vary according to your IdP documentation
-
-
-**IDP certificate:** (base64 encoded Public Cert from the SAML IdP)::
-
-   MIIDazCCAlOgAwIBAgIUFIWdqF4bXK5ajmxEyNJ03uK+5UQwDQYJKoZIhvcNAQELBQAwRTELMAkGA1UEBhMCVVMxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0xOTA5MDQxNjMxNDlaFw0xOTEwMDQxNjMxNDlaMEUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCYbCP4kxftE00X/jtZ057eJLfWbkKaNonbUNyvURL9+1CY8Vg4y5941qZQ+Wib6Em+2TzCVCg4v/6oOAgFtnQApd+h8J+PgQ1iDj369oOhI7I0AwU37fNkGWrQWZi6GqV5xWlApb+3dwY2ag9dKF41n+lf0eFzWXGIaYPRMq3tVt9oz0Jxosuz/aYX2ktEydQTSBng+smUq5vdlnRTqKKu3MFCeDVqb6f9FtXz7xKV/bwcMepz0eOw8TKjfWK3Y4OFKjfHhHFG+ii8eNOFmmHn767K96819v86ehUDpY/h+lKnrnxjv/115Uu0zrB2OAfjvcQZNmfnA/rKL7UjsGl3AgMBAAGjUzBRMB0GA1UdDgQWBBRnqILKxsNGS4iX79uTcjXBBm75XTAfBgNVHSMEGDAWgBRnqILKxsNGS4iX79uTcjXBBm75XTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBRST4IB5O67j9ziSIzaJhhzKzu7QWWeSVcLECyfJ5iik0BMvcC3YB4rSoHo4nWgCCb+EGIaqpotXV5dK2zfCHe85bQCrc5xFZmiKCmN2iLvkF3xc9twlw8yvxSBLO6rqceVNlwJwVVsW/63v3+GXEXm0y9yPYjyr6e/VE6AxAv650dccMThxL/5ZQyceE9qSNMPk2C6kiBTv/ZKosCratsiGOWok56WyCzJyag4I93IEiFRaZlWvtJMDBXYAbgPalwm9MPoU70n6K8Bf8L+Tekt6v1ny8Iv14Whb6l5XMr/r4cqwv2DNwq1xMh59WITgdJwUNB5uLLldm40RRBJtb0
-
-.. note::
-   - The above certificate is just an example, you should use a proper certificate from your IdP!
-   - Note that this is generally NOT the same cert used by TLS in the HTTPS connection to the IdP.
-
-.. hint:: **ADFS users**
+IDP SSO target URL:
+   ``https://{keycloak-FQDN}/auth/realms/master/protocol/saml``
    
-   Above certificate refers to the to the signing certificate.
+   .. note:: This will vary according to your IdP documentation
 
+IDP certificate: (base64 encoded Public Cert from the SAML IdP)
+   .. code-block:: html
+   
+      MIIDazCCAlOgAwIBAgIUFIWdqF4bXK5ajmxEyNJ03uK+5UQwDQYJKoZIhvcNAQELBQAwRTELMAkGA1UEBhMCVVMxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0xOTA5MDQxNjMxNDlaFw0xOTEwMDQxNjMxNDlaMEUxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCYbCP4kxftE00X/jtZ057eJLfWbkKaNonbUNyvURL9+1CY8Vg4y5941qZQ+Wib6Em+2TzCVCg4v/6oOAgFtnQApd+h8J+PgQ1iDj369oOhI7I0AwU37fNkGWrQWZi6GqV5xWlApb+3dwY2ag9dKF41n+lf0eFzWXGIaYPRMq3tVt9oz0Jxosuz/aYX2ktEydQTSBng+smUq5vdlnRTqKKu3MFCeDVqb6f9FtXz7xKV/bwcMepz0eOw8TKjfWK3Y4OFKjfHhHFG+ii8eNOFmmHn767K96819v86ehUDpY/h+lKnrnxjv/115Uu0zrB2OAfjvcQZNmfnA/rKL7UjsGl3AgMBAAGjUzBRMB0GA1UdDgQWBBRnqILKxsNGS4iX79uTcjXBBm75XTAfBgNVHSMEGDAWgBRnqILKxsNGS4iX79uTcjXBBm75XTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBRST4IB5O67j9ziSIzaJhhzKzu7QWWeSVcLECyfJ5iik0BMvcC3YB4rSoHo4nWgCCb+EGIaqpotXV5dK2zfCHe85bQCrc5xFZmiKCmN2iLvkF3xc9twlw8yvxSBLO6rqceVNlwJwVVsW/63v3+GXEXm0y9yPYjyr6e/VE6AxAv650dccMThxL/5ZQyceE9qSNMPk2C6kiBTv/ZKosCratsiGOWok56WyCzJyag4I93IEiFRaZlWvtJMDBXYAbgPalwm9MPoU70n6K8Bf8L+Tekt6v1ny8Iv14Whb6l5XMr/r4cqwv2DNwq1xMh59WITgdJwUNB5uLLldm40RRBJtb0
+   
+   .. note::
+      - The above certificate is just an example, you should use a proper certificate from your IdP!
+      - Note that this is generally **not** the same cert used by TLS in the HTTPS connection to the IdP.
 
-- In Keycloak, this certificate can be found by going to:
-- Keycloak Admin: Realm settings -> keys -> RSA -> "certifcate" popup
-- Paste as a single line string with no line breaks.
-- Do not set this option at all if using the "certificate fingerprint" for cert validation.
+   .. hint:: **ADFS users**
+      
+      Above certificate refers to the to the signing certificate.
 
-**IDP certificate fingerprint:**
-Optionally use the fingerprint instead of the certificate itself for cert validation.
-Because sha1 is used for the fingerprint, this option is not preferred.
-Do not set this option at all if using the "certificate" field above.
+   In Keycloak, this certificate can be found by going to:
+      
+      - Keycloak Admin: Realm settings -> keys -> RSA -> "certifcate" popup
+      - Paste as a single line string with no line breaks.
+      - Do not set this option at all if using the "certificate fingerprint" for cert validation.
+
+IDP certificate fingerprint:
+   Optionally use the fingerprint instead of the certificate itself for cert validation.
+   Because sha1 is used for the fingerprint, this option is not preferred.
+   Do not set this option at all if using the "certificate" field above.
 
 **Name Identifier Format:**
-
-``urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress``
-
-
-Configured example:
-
-.. image:: /images/settings/security/third-party/saml/zammad_connect_saml_thirdparty.png
-   :alt: Zammad SAML Example
-
+   ``urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress``
 
 Configure the SAML IdP
 ----------------------
 
 If your IdP supports xml import or auto xml metadata retrieval, use this URL:
-``https://zammadFQDN/auth/saml/metadata``
+``https://{Zammad-FQDN}/auth/saml/metadata``
 
 For Keycloak IdP, save the contents of that metadata file as "metadata.xml" and then log into Keyclaok and import it as a new Client.
 
 Keycloak sends the "Username" in whatever format your users are stored in. The tested SAML instance used email address for the "username", but Zammad also needs to see an "email" attribute to correctly automap to existing users.
 In Keycloak, we can create a "Mapper" for the newly imported Zammad client.
 
-Goto -> Keycloak Admin -> Clients -> ``https://zammadFQDN/auth/saml/metadata`` -> Mappers -> Create
+Goto -> Keycloak Admin -> Clients -> ``https://{Zammad-FQDN}/auth/saml/metadata`` -> Mappers -> Create
 
 .. code-block:: html
 
@@ -82,24 +76,23 @@ Goto -> Keycloak Admin -> Clients -> ``https://zammadFQDN/auth/saml/metadata`` -
    SAML Attribute NameFormat: Basic
 
 Keycloak needs to know the redirect location in advance for security:
-Goto -> Keycloak Admin -> Clients -> ``https://zammadFQDN/auth/saml/metadata``
+Goto -> Keycloak Admin -> Clients -> ``https://{Zammad-FQDN}/auth/saml/metadata``
 
-**Valid Redirect URIs:**
-
-``https://zammadFQDN/auth/saml/callback``
+Valid Redirect URIs:
+   ``https://{Zammad-FQDN}/auth/saml/callback``
 
 For other IdP systems, you can configure things manually.
 Zammad is using POST Bindings for the Assertion Consumer Service (ACS)
 
+ASC POST Binding URL:
+   ``https://{Zammad-FQDN}/auth/saml/callback``
 
-**ASC POST Binding URL:**
+Zammad requests these attributes from the SAML IdP, these are not configurable. Each attribute should map to the correct 
+SAML attribute via "Mappers" as needed, or equivalent mapping paradigm in other IdP systems.
+The specific attributes to map vary widely between SAML IdP systems, this requested attribute list can help align the SAML 
+provided attributes with what Zammad expects to see.
 
-``https://zammadFQDN/auth/saml/callback``
-
-Zammad requests these attributes from the SAML IdP, these are not configurable. Each attribute should map to the correct SAML attribute via "Mappers" as needed, or equivalent mapping paradigm in other IdP systems.
-The specific attributes to map vary widely between SAML IdP systems, this requested attribute list can help align the SAML provided attributes with what Zammad expects to see.
-
-   .. warn:: Please note that attribute may mean property in some cases! Mappings with user properties should be 
+   .. warning:: Please note that attribute may mean property in some cases! Mappings with user properties should be 
       what you're aiming for.
 
 .. code-block:: html
@@ -109,9 +102,8 @@ The specific attributes to map vary widely between SAML IdP systems, this reques
    RequestedAttribute FriendlyName="Given name" Name="first_name" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic" isRequired="false"
    RequestedAttribute FriendlyName="Family name" Name="last_name" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic" isRequired="false"
 
-
 Now, you should be able to link accounts in the Profile Panel under *Linked Accounts*, or log in via the Zammad login page. Alternately, you can enable :ref:`automatic account linking <automatic_account_linking>` for existing user accounts.
 
 .. hint:: **Having issues with automatic account linking?**
    
-   Changes are high that user attribute or user property mapping isn't configured like it should be. 
+   Changes are high that user attribute or user property mapping isn't configured like it should be.

--- a/settings/security/third-party/saml.rst
+++ b/settings/security/third-party/saml.rst
@@ -34,6 +34,10 @@ Define the fields per your upstream IdP documentation, some known working Keyclo
    - The above certificate is just an example, you should use a proper certificate from your IdP!
    - Note that this is generally NOT the same cert used by TLS in the HTTPS connection to the IdP.
 
+.. hint:: **ADFS users**
+   
+   Above certificate refers to the to the signing certificate.
+
 
 - In Keycloak, this certificate can be found by going to:
 - Keycloak Admin: Realm settings -> keys -> RSA -> "certifcate" popup

--- a/settings/security/third-party/saml.rst
+++ b/settings/security/third-party/saml.rst
@@ -110,7 +110,7 @@ Enable SAML and enter your IdP’s details in the Admin Panel under
    <https://www.schneier.com/blog/archives/2005/02/sha1_broken.html>`_.)
 
    **Keycloak users:** Find your certificate in the Keycloak admin panel under
-   **Clients > https://your.zammad.domain/auth/saml/metadata > SAML Keys**.
+   **Realm Settings > Keys > RSA > Certificate**.
 
 See :ref:`automatic account linking <automatic_account_linking>` for details on how to link existing Zammad accounts to IdP accounts.
 

--- a/settings/security/third-party/saml.rst
+++ b/settings/security/third-party/saml.rst
@@ -76,7 +76,7 @@ Goto -> Keycloak Admin -> Clients -> ``https://zammadFQDN/auth/saml/metadata`` -
 .. code-block:: html
 
    Name: ZammadEmail
-   Mapper Type: User Attribute
+   Mapper Type: User Property
    User Attribute: emailAddress
    SAML Attribute Name: email
    SAML Attribute NameFormat: Basic
@@ -99,6 +99,9 @@ Zammad is using POST Bindings for the Assertion Consumer Service (ACS)
 Zammad requests these attributes from the SAML IdP, these are not configurable. Each attribute should map to the correct SAML attribute via "Mappers" as needed, or equivalent mapping paradigm in other IdP systems.
 The specific attributes to map vary widely between SAML IdP systems, this requested attribute list can help align the SAML provided attributes with what Zammad expects to see.
 
+   .. warn:: Please note that attribute may mean property in some cases! Mappings with user properties should be 
+      what you're aiming for.
+
 .. code-block:: html
 
    RequestedAttribute FriendlyName="Email address" Name="email" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic" isRequired="false"
@@ -108,3 +111,7 @@ The specific attributes to map vary widely between SAML IdP systems, this reques
 
 
 Now, you should be able to link accounts in the Profile Panel under *Linked Accounts*, or log in via the Zammad login page. Alternately, you can enable :ref:`automatic account linking <automatic_account_linking>` for existing user accounts.
+
+.. hint:: **Having issues with automatic account linking?**
+   
+   Changes are high that user attribute or user property mapping isn't configured like it should be. 


### PR DESCRIPTION
This merge request comes with a lot of different flavors.
First of all, to initially help users better, we improved two possible use cases:

* ADFS users now can find a direct hint what certificate to use (this caused confusion earlier)
* As on current support cases and a community post it became clear that "user attribute" in some cases has to be "user property" which now is stated in the docs.

To further improve the documentation, I also adjusted formatting of the page. This means I'm using more levels in order to force more structure on the page.

(hopefully) to make Ryan initially happier and reduce his load I also

* removed all white spaces that shouldn't be there
* removed blank lines not being needed

This has no super top priority - take the time you need! :)