### PR TITLE
Enhance information regarding notification channel

### DIFF
--- a/channels/email/accounts/email-notification.rst
+++ b/channels/email/accounts/email-notification.rst
@@ -26,7 +26,8 @@ Host
 User
    Your account login/username.
 
-   .. hint:: The notification sender address can be configured within the :doc:`Settings tab <../settings>`.
+   .. hint:: The “From:” address on system notifications can be configured under
+      :doc:`Channels > Email > Settings > Notification Sender <../settings>`.
 
 Password
    Your account password.

--- a/channels/email/accounts/email-notification.rst
+++ b/channels/email/accounts/email-notification.rst
@@ -26,6 +26,8 @@ Host
 User
    Your account login/username.
 
+   .. hint:: The notification sender address can be configured within the :doc:`Settings tab <../settings>`.
+
 Password
    Your account password.
 

--- a/channels/email/index.rst
+++ b/channels/email/index.rst
@@ -35,7 +35,7 @@ Control how Zammad **sends and receives email**.
 :doc:`⚙️  Settings <settings>`
    Manage options like: 
 
-   * set the “From:” address on auto-replies
+   * set the “From:” address on system notifications
    * raise the limit on attachment sizes
    * modify subject-line prefixes (*e.g.,* use “AW:” instead of “RE:”)
 


### PR DESCRIPTION
Up to now the documentation doesn't declare a notification channel being dependent on the notification sender address.
This leads to confusion on new members especially in situations where you start using SMTP which restrictive mail servers that only allow specific mail addresses per user.

This pull request adds a direct hint within the channel notification detail dialogue.
Also, earlier the wording for email notification channels on the overview page was stating this channel being relevant for "auto-replies" which is miss leading. This is why I replaced it with a more fitting wording.