### PR TITLE
Fixes 89 - Clarify what the kb read permission does

### DIFF
--- a/manage/roles/agent-permissions.rst
+++ b/manage/roles/agent-permissions.rst
@@ -31,7 +31,11 @@ Agent Permissions
 :knowledge_base:            `📕 Knowledge Base <https://user-docs.zammad.org/en/latest/extras/knowledge-base.html>`_ 
                             
                             :``knowledge_base.editor``:     create/edit privileges
-                            :``knowledge_base.reader``:     read privileges for internal & public content
+                            :``knowledge_base.reader``:     read privileges for internal content
+
+                                                            .. hint::
+
+                                                               Public articles are always visible.
 :``report``:                :doc:`📈 Reporting </manage/report-profiles>`
 
                             .. warning:: 🙅 **Never grant this permission to your customers.**


### PR DESCRIPTION
This PR improves the permission wording for administrators in context for ``knowlegde_base.reader`` permission.