### PR TITLE
Extend knowledgebase editor permission with hint

### DIFF
--- a/manage/roles/agent-permissions.rst
+++ b/manage/roles/agent-permissions.rst
@@ -31,6 +31,10 @@ Agent Permissions
 :knowledge_base:            `📕 Knowledge Base <https://user-docs.zammad.org/en/latest/extras/knowledge-base.html>`_ 
                             
                             :``knowledge_base.editor``:     create/edit privileges
+
+                                                            .. hint::
+
+                                                              Editor permissions always include reader permissions.
                             :``knowledge_base.reader``:     read privileges for internal content
 
                                                             .. hint::


### PR DESCRIPTION
As it might be confusing why a editor automatically receives reader permission as well (without ticking those in), we've added a remark on this behavior.

@Martin - could you please check if my wording is good enough for this case? :)
Do you miss anything?