### PR TITLE
Remove "missing docs" hint for generic oAuth2

### DIFF
--- a/settings/security.rst
+++ b/settings/security.rst
@@ -74,7 +74,6 @@ Another big advantage of this feature is that your user doesn't need another pas
 .. note:: We're currently missing documentation for the following login providers:
 
    * LinkedIn
-   * Generic OAuth2
    * Weibo
 
 .. _automatic-account-linking:


### PR DESCRIPTION
oAuth2 (generic) was considered broken for a while now. We will finally remove it from Zammad to reduce the broad confusion the functionality provides.

See https://github.com/zammad/zammad/issues/2951 for reasons etc.