### PR TITLE
Fixes #101 - Rename text templates to text modules

### DIFF
--- a/manage/text-modules.rst
+++ b/manage/text-modules.rst
@@ -1,14 +1,18 @@
 Text Modules
 ============
 
-.. note:: Beside text modules Zammad also allows you to use `Ticket-Templates for ticket creation <https://user-docs.zammad.org/en/latest/advanced/ticket-templates.html>`_.
+.. note:: 
+
+   Beside text modules Zammad also allows you to use `Ticket-Templates for ticket 
+   creation <https://user-docs.zammad.org/en/latest/advanced/ticket-templates.html>`_.
 
 
 Text modules
 ------------
 
 Text modules can be edited in the admin interface under Manage --> Text modules.
-Here you will find text snippets already created in the standard version, which can be extended as needed.
+Here you will find text snippets already created in the standard version, which 
+can be extended as needed.
 
 .. image:: /images/manage/Zammad_Helpdesk_-_Text_modules.jpg
 
@@ -20,21 +24,29 @@ Creating keywords makes it easier to find the right text module.
    :alt: You can find text modules either by their name or keyword.
 
 If needed, you can restrict text modules to specific groups.
-With this, you can easilly keep text module lists short and dedicate specific texts to where they belong.
+With this, you can easilly keep text module lists short and dedicate specific 
+texts to where they belong.
 
 You can adjust the group memberships for text modules at any time.
-This allows you to have the text module available globally (no groups selected) or one or several specific groups.
+This allows you to have the text module available globally (no groups selected) 
+or one or several specific groups.
 
 .. figure:: /images/manage/text-module-group-specific.png
    :alt: Example: Restricting text modules to 2nd Level group only.
 
-To select placeholders from a list, just enter "::" in the text block. The list can be searched with the arrow keys after inputting keywords or shortcuts.
-All text modules can be used in articles as well as in the chat.
+To select placeholders from a list, just enter ``::`` in the text block. 
+The list can be searched with the arrow keys after inputting keywords or 
+shortcuts. All text modules can be used in articles as well as in the chat.
 
-.. note:: You can find more information on how to use text modules on our `User Documentation <https://user-docs.zammad.org/en/latest/advanced/text-modules.html>`_.
+.. note:: 
+
+   You can find more information on how to use text modules on our 
+   `User Documentation <https://user-docs.zammad.org/en/latest/advanced/text-modules.html>`_.
 
 
-.. tip:: If text modules are to be grouped, this can be done using shortcuts. Example country codes:
+.. tip:: 
+   If text modules are to be grouped, this can be done using shortcuts. 
+   Example country codes:
 
    Text modules are created for the group Germany as follows:
 
@@ -52,7 +64,8 @@ All text modules can be used in articles as well as in the chat.
 
 
 
-The example text modules below use :doc:`/system/variables` to dynamically insert information like the customer’s or agent’s names.
+The example text modules below use :doc:`/system/variables` to dynamically 
+insert information like the customer’s or agent’s names.
 
 **Examples of snippets are**::
 
@@ -70,18 +83,24 @@ Of course you can also use multi line snippets.
 Delete or clone text modules
 ----------------------------
 
-Often similar text modules have to be created or unnecessary ones deleted. For these cases you can click on the 3 points in the text module overview on the right side and select the corresponding action:
+Often similar text modules have to be created or unnecessary ones deleted. 
+For these cases you can click on the 3 points in the text module overview on 
+the right side and select the corresponding action:
 
 .. image:: /images/manage/Zammad_Helpdesk_-_Text_modules-clone.jpg
 
-When cloning, text modules with all attributes are duplicated and can be edited later.
+When cloning, text modules with all attributes are duplicated and can be edited 
+later.
 
 
 Import of text modules via CSV file
 -----------------------------------
 
-With the import action (since Zammad 2.5) you can download a sample CSV file and upload your own CSV file.
+With the import action (since Zammad 2.5) you can download a sample CSV file 
+and upload your own CSV file.
 
-To reduce the error rate of unwanted mass changes, a test import is carried out first and a summary appears at the end. If you agree with the summary, the CSV import will be executed.
+To reduce the error rate of unwanted mass changes, a test import is carried out 
+first and a summary appears at the end. If you agree with the summary, the CSV 
+import will be executed.
 
 .. image:: /images/manage/Zammad_Helpdesk_-_Text_modules-Import.jpg

--- a/manage/text-modules.rst
+++ b/manage/text-modules.rst
@@ -6,10 +6,6 @@ Text Modules
    Beside text modules Zammad also allows you to use `Ticket-Templates for ticket 
    creation <https://user-docs.zammad.org/en/latest/advanced/ticket-templates.html>`_.
 
-
-Text modules
-------------
-
 Text modules can be edited in the admin interface under Manage --> Text modules.
 Here you will find text snippets already created in the standard version, which 
 can be extended as needed.

--- a/manage/text-modules.rst
+++ b/manage/text-modules.rst
@@ -1,5 +1,5 @@
-Text Templates
-==============
+Text Modules
+============
 
 .. warning:: With Zammad 3.1 we introduced group based text modules. This documentation contains information that might no longer apply to Zammad versions earlier 3.1.
 

--- a/manage/text-modules.rst
+++ b/manage/text-modules.rst
@@ -1,10 +1,6 @@
 Text Modules
 ============
 
-.. warning:: With Zammad 3.1 we introduced group based text modules. This documentation contains information that might no longer apply to Zammad versions earlier 3.1.
-
-Create text templates to spend less time writing responses. You can create text passages (Text modules) or even entire response templates.
-
 .. note:: Beside text modules Zammad also allows you to use `Ticket-Templates for ticket creation <https://user-docs.zammad.org/en/latest/advanced/ticket-templates.html>`_.
 
 
@@ -89,10 +85,3 @@ With the import action (since Zammad 2.5) you can download a sample CSV file and
 To reduce the error rate of unwanted mass changes, a test import is carried out first and a summary appears at the end. If you agree with the summary, the CSV import will be executed.
 
 .. image:: /images/manage/Zammad_Helpdesk_-_Text_modules-Import.jpg
-
-
-
-Ticket templates for new tickets
---------------------------------
-
-Ticket templates in new tickets can be created by any agent. Therefore you will find information inside of our `User-Documentation <https://user-docs.zammad.org/en/latest/advanced/ticket-templates.html>`_ .


### PR DESCRIPTION
Beside of the head line rename I also cleaned up the files structure slightly and removed duplicate / obsolete information.