### PR TITLE
Fix Keycloak attribute to map

### DIFF
--- a/settings/security/third-party/saml.rst
+++ b/settings/security/third-party/saml.rst
@@ -77,7 +77,7 @@ Keycloak
      +-------------------------------+------------------------------------------------+
      | **Mapper Type**               | User Property                                  |
      +-------------------------------+------------------------------------------------+
-     | **Property**                  | emailAddress                                   |
+     | **Property**                  | email                                          |
      +-------------------------------+------------------------------------------------+
      | **SAML Attribute Name**       | email                                          |
      +-------------------------------+------------------------------------------------+
@@ -86,7 +86,7 @@ Keycloak
 
      In the example above, we’re telling Zammad that
      whenever it receives a SAML login request,
-     it should take the ``emailAddress`` property from Keycloak,
+     it should take the ``email`` property from Keycloak,
      look for a Zammad user with the same ``email`` attribute,
      and create a new session for that user.
 


### PR DESCRIPTION
Keycloak attribute to map for SAML is not `emailAddress` but only `email` (at least on Keycloak 15.0+).