### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/es/LC_MESSAGES/admin-docs.po
+++ b/locale/es/LC_MESSAGES/admin-docs.po
@@ -8,9 +8,8 @@ msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-09-29 12:42+0200\n"
-"PO-Revision-Date: 2022-06-28 20:09+0000\n"
-"Last-Translator: Agustin Ortiz de Montellano Galeazzi <agustin."
-"montellano@grupoeho.com>\n"
+"PO-Revision-Date: 2022-10-22 15:14+0000\n"
+"Last-Translator: Carlos Jara <carlos.jara@gmail.com>\n"
 "Language-Team: Spanish <https://translations.zammad.org/projects/"
 "documentations/admin-documentation/es/>\n"
 "Language: es\n"
@@ -18,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.13\n"
+"X-Generator: Weblate 4.14.1\n"
 
 #: ../channels/chat.rst:2
 msgid "Chat"
@@ -2344,7 +2343,7 @@ msgstr ""
 
 #: ../channels/form.rst:63 ../system/subscription/billing.rst:57
 msgid "Description"
-msgstr ""
+msgstr "Descripción"
 
 #: ../channels/form.rst:64
 msgid "``form_ticket_create_by_ip_per_hour``"
@@ -5008,7 +5007,7 @@ msgstr ""
 
 #: ../manage/macros.rst:2
 msgid "Macros"
-msgstr ""
+msgstr "Macros"
 
 #: ../manage/macros.rst:4
 msgid "Macros are **🖱️ one-click shortcuts** for applying changes to a ticket."
@@ -12185,7 +12184,7 @@ msgstr ""
 
 #: ../system/integrations/checkmk/api-reference.rst:13
 msgid "Example"
-msgstr ""
+msgstr "Ejemplo"
 
 #: ../system/integrations/checkmk/api-reference.rst:15
 msgid ""
@@ -12378,7 +12377,7 @@ msgstr ""
 
 #: ../system/integrations/checkmk/api-reference.rst:137
 msgid "group"
-msgstr ""
+msgstr "grupo"
 
 #: ../system/integrations/checkmk/api-reference.rst:138
 #: ../system/integrations/checkmk/api-reference.rst:172
@@ -12387,11 +12386,11 @@ msgstr ""
 
 #: ../system/integrations/checkmk/api-reference.rst:139
 msgid "state"
-msgstr ""
+msgstr "estado"
 
 #: ../system/integrations/checkmk/api-reference.rst:140
 msgid "priority"
-msgstr ""
+msgstr "prioridad"
 
 #: ../system/integrations/checkmk/api-reference.rst:142
 msgid ""
@@ -12405,7 +12404,7 @@ msgstr ""
 
 #: ../system/integrations/checkmk/api-reference.rst:147
 msgid "title"
-msgstr ""
+msgstr "título"
 
 #: ../system/integrations/checkmk/api-reference.rst:148
 msgid "id"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentations/Admin Documentation (latest)](https://translations.zammad.org/projects/documentations/admin-documentation/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widgets/documentations/-/admin-documentation/horizontal-auto.svg)