### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/pt_BR/LC_MESSAGES/admin-docs.po
+++ b/locale/pt_BR/LC_MESSAGES/admin-docs.po
@@ -8,16 +8,16 @@ msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-01-10 15:21+0100\n"
-"PO-Revision-Date: 2022-08-01 14:09+0000\n"
-"Last-Translator: Erico Cesar <ericocesar@webck.com.br>\n"
+"PO-Revision-Date: 2024-02-04 05:00+0000\n"
+"Last-Translator: Thiago Blake <thiago@giganet.inf.br>\n"
 "Language-Team: Portuguese (Brazil) <https://translations.zammad.org/projects/"
-"documentations/admin-documentation/pt_BR/>\n"
+"documentations/admin-documentation-pre-release/pt_BR/>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.13\n"
+"X-Generator: Weblate 5.3\n"
 
 #: ../channels/chat.rst:2
 msgid "Chat"
@@ -62,27 +62,31 @@ msgstr "Resolvendo meu problema rapidamente"
 
 #: ../channels/chat.rst:25
 msgid "Bad experiences"
-msgstr ""
+msgstr "Experiências ruins"
 
 #: ../channels/chat.rst:20
 msgid ""
 "A chat window on a website (while the chat being offline) with the hint to "
 "\"Leave a message\""
 msgstr ""
+"Uma janela de chat em um site (enquanto o chat está offline) com a indicação "
+"de \"Deixe uma mensagem\""
 
 #: ../channels/chat.rst:22
 msgid "Long waiting queues before even writing with a personal"
-msgstr ""
+msgstr "Longas filas de espera antes mesmo de falar com um atendente"
 
 #: ../channels/chat.rst:23
 msgid ""
 "Receiving a message like \"My name is Nina, what can I do for you?\" after "
 "sending a message with my issue."
 msgstr ""
+"Recebendo uma mensagem como \"Meu nome é Nina, o que posso fazer por você?\" "
+"depois de enviar uma mensagem com meu problema."
 
 #: ../channels/chat.rst:25
 msgid "A Chat that doesn't integrate itself into the Website properly"
-msgstr "Um Chat que não se integra corretamente com um Website"
+msgstr "Um Chat que não se integra corretamente ao Website"
 
 #: ../channels/chat.rst:28
 msgid "Our answer: The Zammad Chat Widget"
@@ -93,10 +97,12 @@ msgid ""
 "The task is clear: Work on the disadvantages of a regular support chat and "
 "improve them."
 msgstr ""
+"A tarefa é clara: Trabalhar nas desvantagens de um chat de suporte regular e "
+"melhorá-las."
 
 #: ../channels/chat.rst:46
 msgid "Our approach is as follows"
-msgstr ""
+msgstr "Nossa abordagem é a seguinte"
 
 #: ../channels/chat.rst:34
 msgid ""

--- a/locale/sv/LC_MESSAGES/admin-docs.po
+++ b/locale/sv/LC_MESSAGES/admin-docs.po
@@ -8,17 +8,21 @@ msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-01-10 15:21+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"PO-Revision-Date: 2024-02-01 11:00+0000\n"
+"Last-Translator: kjellbrandes <kjell@zippit.se>\n"
+"Language-Team: Swedish <https://translations.zammad.org/projects/"
+"documentations/admin-documentation-pre-release/sv/>\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.3\n"
 
 #: ../channels/chat.rst:2
+#, fuzzy
 msgid "Chat"
-msgstr ""
+msgstr "Chat"
 
 #: ../channels/chat.rst:4
 msgid ""
@@ -38,7 +42,7 @@ msgstr ""
 
 #: ../channels/chat.rst:17
 msgid "Good experiences"
-msgstr ""
+msgstr "Bra erfarenheter"
 
 #: ../channels/chat.rst:15
 msgid "Getting personal support by a human being"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/Admin Documentation (pre-release)](https://translations.zammad.org/projects/documentations/admin-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/admin-documentation-pre-release/horizontal-auto.svg)