### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/de/LC_MESSAGES/admin-docs.po
+++ b/locale/de/LC_MESSAGES/admin-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-03-26 14:49+0100\n"
-"PO-Revision-Date: 2024-03-27 02:05+0000\n"
+"PO-Revision-Date: 2024-04-03 09:00+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
 "documentations/admin-documentation-pre-release/de/>\n"
@@ -11317,6 +11317,8 @@ msgid ""
 "This can be activated with the switch labeled \"Localization of execution "
 "changes\"."
 msgstr ""
+"Dies kann mit dem Schalter \"Sprache für ausgeführte Aktionen\" aktiviert "
+"werden."
 
 #: ../manage/scheduler.rst:89
 msgid ""
@@ -11324,6 +11326,10 @@ msgid ""
 "by using the ``t`` function. For more information, please have a look at the "
 "explanation in the :ref:`variables section <variable_localization>`."
 msgstr ""
+"Legen Sie eine gewünschte Sprache fest, in die die Ausgabe von Variablen mit "
+"Hilfe der Funktion ``t`` übersetzt werden soll. Für weitere Informationen "
+"sehen Sie sich bitte die Erklärung im Abschnitt :ref:`Variablen "
+"<variable_localization>` an."
 
 #: ../manage/scheduler.rst:101 ../settings/branding.rst:44
 msgid "Timezone"
@@ -11336,6 +11342,10 @@ msgid ""
 "have a look at the explanation in the :ref:`variables section "
 "<variable_localization>`."
 msgstr ""
+"Ähnlich wie bei der \"Sprache\"-Einstellung können Sie eine Zeitzone "
+"definieren, die auf die Ausgabe von Zeitstempel-Variablen angewendet wird. "
+"Für weitere Informationen schauen Sie sich bitte die Erklärung im Bereich "
+":ref:`Variablen <variable_localization>` an."
 
 #: ../manage/scheduler.rst:104
 msgid ""
@@ -12950,8 +12960,6 @@ msgid "Screenshot of “Triggers” page in admin panel"
 msgstr "Screenshot der \"Trigger\" in den Einstellungen"
 
 #: ../manage/trigger/how-do-they-work.rst:2
-#, fuzzy
-#| msgid "How do trigger work"
 msgid "How Do Trigger Work"
 msgstr "Wie funktionieren Trigger"
 
@@ -13065,10 +13073,8 @@ msgstr ""
 "verschoben wurde, während die Priorität **1 niedrig** eingestellt war."
 
 #: ../manage/trigger/how-do-they-work.rst:49
-#, fuzzy
-#| msgid "Time event"
 msgid "Time Event"
-msgstr "Time event"
+msgstr "Zeitereignis"
 
 #: ../manage/trigger/how-do-they-work.rst:51
 msgid ""
@@ -13214,13 +13220,16 @@ msgstr ""
 
 #: ../manage/trigger/how-do-they-work.rst:115
 msgid "Localization of Execution Changes"
-msgstr ""
+msgstr "Sprache für ausgeführte Aktionen"
 
 #: ../manage/trigger/how-do-they-work.rst:117
 msgid ""
 "To translate the output of variables, use the ``t`` function. To format date "
 "and time stamps, use the ``dt`` function."
 msgstr ""
+"Um die Ausgabe von Variablen zu übersetzen, verwenden Sie die Funktion ``t``"
+". Um Datums- und Zeitstempel zu formatieren, verwenden Sie die Funktion "
+"``dt``."
 
 #: ../manage/trigger/how-do-they-work.rst:120
 msgid ""
@@ -13228,24 +13237,30 @@ msgid ""
 "selected \"Locale\". The ``dt`` function transforms a date and time stamp "
 "according to the selected \"Timezone\"."
 msgstr ""
+"Die Funktion ``t`` übersetzt die Ausgabe von Variablen entsprechend der "
+"gewählten \"Sprache\". Die Funktion ``dt`` wandelt einen Datums- und "
+"Zeitstempel entsprechend der gewählten \"Zeitzone\" um."
 
 #: ../manage/trigger/how-do-they-work.rst:None
-#, fuzzy
-#| msgid "Screenshot showing certificate adding dialog"
 msgid "Screenshot showing localization section of trigger dialog"
-msgstr "Screenshot zeigt Dialog zum Hinzufügen von Zertifikaten"
+msgstr "Screenshot zeigt Sprachanpassung im Trigger-Dialog"
 
 #: ../manage/trigger/how-do-they-work.rst:130
 msgid ""
 "Best practice is to create single separated localized triggers for each "
 "language/timezone and execute them based on user or organization attributes."
 msgstr ""
+"Es empfiehlt sich, für jede Sprache/Zeitzone einen eigenen angepassten "
+"Trigger zu erstellen und diesen auf der Grundlage von Benutzer- oder "
+"Organisationsattributen auszuführen."
 
 #: ../manage/trigger/how-do-they-work.rst:133
 msgid ""
 "For more information and examples, please have a look at the explanation in "
 "the :ref:`variables section <variable_localization>`."
 msgstr ""
+"Weitere Informationen und Beispiele finden Sie in der Erläuterung im Bereich "
+":ref:`Variablen <variable_localization>`."
 
 #: ../manage/trigger/learn-by-example.rst:2
 msgid "Trigger examples"
@@ -29753,10 +29768,8 @@ msgstr ""
 "Stunde des Tages in 24-Stunden-Schreibweise, ggf. mit vorangestellter Null"
 
 #: ../system/variables.rst:117
-#, fuzzy
-#| msgid "Use ``%e`` for day without zero-padding"
 msgid "Use ``%k`` for hour without zero-padding"
-msgstr "Verwenden Sie ``%e`` für Tage ohne vorangestellte Null"
+msgstr "Verwenden Sie ``%k`` für Stunden ohne führende Null"
 
 #: ../system/variables.rst:118
 msgid "``%I``"
@@ -29787,8 +29800,6 @@ msgid "``%S``"
 msgstr "``%S``"
 
 #: ../system/variables.rst:125
-#, fuzzy
-#| msgid "Second of hour"
 msgid "Second of Minute"
 msgstr "Sekunde der Minute"
 


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/Admin Documentation (pre-release)](https://translations.zammad.org/projects/documentations/admin-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/admin-documentation-pre-release/horizontal-auto.svg)