### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/sr/LC_MESSAGES/admin-docs.po
+++ b/locale/sr/LC_MESSAGES/admin-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad Admin Documentation pre-release\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-05-03 14:36+0200\n"
-"PO-Revision-Date: 2024-05-04 01:06+0000\n"
+"PO-Revision-Date: 2024-05-15 09:00+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
 "documentations/admin-documentation-pre-release/sr/>\n"
@@ -6597,12 +6597,11 @@ msgstr "Услови"
 msgid ""
 "First, make sure you have followed our :doc:`preparation guide<preparation>`."
 msgstr ""
+"Прво, уверите се да сте испратили наш :doc:`припремни водич <preparation>`."
 
 #: ../channels/whatsapp/prerequisites.rst:6
-#, fuzzy
-#| msgid "Additionally, you have to meet the following requirements:"
 msgid "Then, check if you meet the following requirements:"
-msgstr "Додатно, мораћете да обезбедите следеће услове:"
+msgstr "Затим, проверите да ли сте обезбедили следеће услове:"
 
 #: ../channels/whatsapp/prerequisites.rst:8
 msgid ""
@@ -8114,10 +8113,8 @@ msgstr ""
 "дугмета при врху прозора."
 
 #: ../manage/knowledge-base.rst:202
-#, fuzzy
-#| msgid "Group Permissions"
 msgid "Permissions"
-msgstr "Групне дозволе"
+msgstr "Дозволе"
 
 #: ../manage/knowledge-base.rst:204
 msgid ""
@@ -8125,6 +8122,9 @@ msgid ""
 "reader`` and ``knowledge_base.editor`` permissions. You can find more "
 "information about roles and permissions :doc:`here <roles/index>`."
 msgstr ""
+"Општи приступ бази знања је омогућен путем ``knowledge_base.reader`` и "
+"``knowledge_base.editor`` дозвола. Можете сазнати више о улогама и дозволама "
+":doc:`овде <roles/index>`."
 
 #: ../manage/knowledge-base.rst:209
 msgid ""
@@ -8132,48 +8132,57 @@ msgid ""
 "permissions (e.g. edit permissions only for specific parts of the knowledge "
 "base), you can do so by following the steps below:"
 msgstr ""
+"Уколико желите да доделите грануларније дозволе од глобалних дозвола читања/"
+"уређивања (нпр. дозвола уређивања само за одговарајуће делове базе знања), "
+"то можете учинити пратећи кораке испод:"
 
 #: ../manage/knowledge-base.rst:213
 msgid ""
 "First create the base structure of the knowledge base (if not already done)"
 msgstr ""
+"Прво креирајте основну структуру базе знања (уколико то већ нисте учинили)"
 
 #: ../manage/knowledge-base.rst:214
 msgid ""
 "Create or choose one or more roles which should have granular permissions"
 msgstr ""
+"Креирајте или одаберите једну или више улога које треба да имају грануларне "
+"дозволе"
 
 #: ../manage/knowledge-base.rst:215
 msgid "Grant the ``knowlege_base.reader`` permission to the desired role(s)"
-msgstr ""
+msgstr "Доделите ``knowlege_base.reader`` дозволу жељеној улози/улогама"
 
 #: ../manage/knowledge-base.rst:216
-#, fuzzy
-#| msgid "Customize the appearance of the knowledge base."
 msgid "Edit the permissions of each (sub-)category of the knowledge base"
-msgstr "Прилагодите изглед базе знања."
+msgstr "Уредите дозволе сваке (под)категорије базе знања"
 
 #: ../manage/knowledge-base.rst:217
 msgid ""
 "Assign the role to one or more users who should be able to edit the "
 "knowledge base (partially)"
 msgstr ""
+"Доделите улогу једном или више корисника који треба да уређују базу знања "
+"(делимично)"
 
 #: ../manage/knowledge-base.rst:222
 msgid "The permissions of a parent category are inherited to sub-categories."
-msgstr ""
+msgstr "Дозволе надређене категорије се наслеђују од стране подкатегорија."
 
 #: ../manage/knowledge-base.rst:223
 msgid ""
 "The permission ``knowledge_base.reader`` can be widened or restricted in sub-"
 "categories."
 msgstr ""
+"Дозвола ``knowledge_base.reader`` се може проширити или ограничити у "
+"подкатегоријама."
 
 #: ../manage/knowledge-base.rst:225
 msgid ""
 "The permission ``knowledge_base.editor`` **can't** be adjusted in sub-"
 "categories."
 msgstr ""
+"Дозвола ``knowledge_base.editor`` се **не може** изменити у подкатегоријама."
 
 #: ../manage/knowledge-base.rst:227
 msgid ""
@@ -8181,6 +8190,8 @@ msgid ""
 "base.html>` in the user documentation where you can find more information "
 "about the usage."
 msgstr ""
+"Погледајте user-docs:`одељак о бази знања </extras/knowledge-base.html>` у "
+"корисничкој документацији за више информација о коришћењу."
 
 #: ../manage/macros.rst:2
 msgid "Macros"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/Admin Documentation (pre-release)](https://translations.zammad.org/projects/documentations/admin-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/admin-documentation-pre-release/horizontal-auto.svg)