### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/sr/LC_MESSAGES/admin-docs.po
+++ b/locale/sr/LC_MESSAGES/admin-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad Admin Documentation pre-release\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-07-09 11:16+0200\n"
-"PO-Revision-Date: 2024-07-11 08:00+0000\n"
+"PO-Revision-Date: 2024-07-15 13:00+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
 "documentations/admin-documentation-pre-release/sr/>\n"
@@ -18870,10 +18870,6 @@ msgid "Certificate (PEM)"
 msgstr "Сертификат (PEM)"
 
 #: ../settings/security/third-party/saml.rst:172
-#, fuzzy
-#| msgid ""
-#| "Paste the public certificate of your Zammad SAML client, if you want to "
-#| "enrypt the requests."
 msgid ""
 "Paste the public certificate of your Zammad SAML client, if you want to "
 "encrypt the requests."
@@ -18882,26 +18878,20 @@ msgstr ""
 "шифровање захтева."
 
 #: ../settings/security/third-party/saml.rst:175
-#, fuzzy
-#| msgid "Are you sure the recipient's certificate is valid?"
 msgid "Make sure the certificate is:"
-msgstr "Да ли сте сигурни да је сертификат примаоца важећи?"
+msgstr "Уверите се да је сертификат:"
 
 #: ../settings/security/third-party/saml.rst:177
 msgid "already valid and not yet expired"
-msgstr ""
+msgstr "већ важећи и није још истекао"
 
 #: ../settings/security/third-party/saml.rst:178
-#, fuzzy
-#| msgid "IDP certificate"
 msgid "no CA certificate"
-msgstr "IDP сертификат"
+msgstr "није CA сертификат"
 
 #: ../settings/security/third-party/saml.rst:179
-#, fuzzy
-#| msgid "Signing & Encrypting"
 msgid "valid for signing and encrypting"
-msgstr "Потписивање и шифровање"
+msgstr "важећи за потписивање и шифровање"
 
 #: ../settings/security/third-party/saml.rst:185
 msgid "Private key (PEM)"
@@ -18917,7 +18907,7 @@ msgstr ""
 
 #: ../settings/security/third-party/saml.rst:185
 msgid "Make sure the key is an RSA key with a length of at least 2048 bits."
-msgstr ""
+msgstr "Уверите се да је тајни кључ RSA дужине од најмање 2048 бита."
 
 #: ../settings/security/third-party/saml.rst:188
 msgid "Private key secret"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/Admin Documentation (pre-release)](https://translations.zammad.org/projects/documentations/admin-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/admin-documentation-pre-release/horizontal-auto.svg)