### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/sr/LC_MESSAGES/admin-docs.po
+++ b/locale/sr/LC_MESSAGES/admin-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad Admin Documentation pre-release\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-08-05 12:42+0200\n"
-"PO-Revision-Date: 2024-07-31 12:00+0000\n"
+"PO-Revision-Date: 2024-08-10 08:00+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
 "documentations/admin-documentation-latest/sr/>\n"
@@ -2817,10 +2817,8 @@ msgstr ""
 "бисте послали коментар."
 
 #: ../channels/form.rst:2
-#, fuzzy
-#| msgid "Forms"
 msgid "Form"
-msgstr "Форме"
+msgstr "Форма"
 
 #: ../channels/form.rst:4
 msgid ""
@@ -13819,10 +13817,8 @@ msgid "ticket attributes/metadata"
 msgstr "атрибути тикета/метаподаци"
 
 #: ../manage/webhook.rst:33
-#, fuzzy
-#| msgid "*all* associated articles"
 msgid "associated article(s)"
-msgstr "*сви* повезани чланци"
+msgstr "повезани чланци"
 
 #: ../manage/webhook.rst:34
 msgid "associated users (e.g. article senders, owners, etc.)"
@@ -16699,7 +16695,7 @@ msgstr "атрибуте група"
 
 #: ../misc/object-conditions/basics.rst:446
 msgid "Differences in input fields:"
-msgstr "Разлике у пољима за унос"
+msgstr "Разлике у пољима за унос:"
 
 #: ../misc/object-conditions/basics.rst:436
 msgid ""


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/Admin Documentation (latest)](https://translations.zammad.org/projects/documentations/admin-documentation-latest/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/admin-documentation-latest/horizontal-auto.svg)