### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/cs/LC_MESSAGES/admin-docs.po
+++ b/locale/cs/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: 2023-09-23 01:11+0000\n"
 "Last-Translator: Tomáš Kovařík <tomas.kovarik@cdv.cz>\n"
 "Language-Team: Czech <https://translations.zammad.org/projects/"
@@ -532,8 +532,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr ""
 
@@ -2792,7 +2791,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr ""
 
@@ -10548,7 +10548,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13189,7 +13188,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13224,7 +13223,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22525,146 +22523,165 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
-msgstr ""
+#, fuzzy
+#| msgid "Version"
+msgid "Attribute Permissions"
+msgstr "Verze"
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
 msgstr ""
 
-#: ../system/objects/permissions.rst:45
-msgid "edit"
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr ""
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+msgid "admin.group"
 msgstr ""
 
 #: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+msgid "Creation dialog for not yet existing data"
+msgstr ""
+
+#: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+msgid "ticket.customer"
+msgstr ""
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+msgid "ticket.agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
+msgid "edit"
+msgstr ""
+
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/da/LC_MESSAGES/admin-docs.po
+++ b/locale/da/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -499,8 +499,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr ""
 
@@ -2759,7 +2758,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr ""
 
@@ -10509,7 +10509,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13150,7 +13149,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13185,7 +13184,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22484,146 +22482,163 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr ""
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
 msgstr ""
 
-#: ../system/objects/permissions.rst:45
-msgid "edit"
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr ""
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+msgid "admin.group"
 msgstr ""
 
 #: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+msgid "Creation dialog for not yet existing data"
+msgstr ""
+
+#: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+msgid "ticket.customer"
+msgstr ""
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+msgid "ticket.agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
+msgid "edit"
+msgstr ""
+
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/de/LC_MESSAGES/admin-docs.po
+++ b/locale/de/LC_MESSAGES/admin-docs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
-"PO-Revision-Date: 2024-08-13 08:00+0000\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
+"PO-Revision-Date: 2024-08-17 08:00+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
 "documentations/admin-documentation-pre-release/de/>\n"
@@ -618,8 +618,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr "Benutzer"
 
@@ -3390,7 +3389,8 @@ msgstr "Standardwert"
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -7300,8 +7300,8 @@ msgid ""
 msgstr ""
 "Die Checkliste ermöglicht es Agenten, den Überblick über die zu erledigenden "
 "Aufgaben zu behalten. Das Feature ist standardmäßig aktiviert und wird in "
-"einem weiteren Tab in der rechten Seitenleiste der Ticket-Ansicht angezeigt ("
-"siehe :user-docs:`hier </extras/checklist.html>`, wie es aus der Sicht von "
+"einem weiteren Tab in der rechten Seitenleiste der Ticket-Ansicht angezeigt "
+"(siehe :user-docs:`hier </extras/checklist.html>`, wie es aus der Sicht von "
 "Agenten aussieht)."
 
 #: ../manage/checklist.rst:None
@@ -13101,7 +13101,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr "Organisation"
 
@@ -16435,7 +16434,7 @@ msgstr "Objektbedingungen"
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr "Einführung"
 
@@ -16483,7 +16482,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr "Gruppe"
 
@@ -28208,173 +28206,189 @@ msgstr ""
 "<link-templates>`."
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr "Berechtigungen für Attribute"
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
-"Einige der möglichen Berechtigungs- und Ansichtsoptionen für Objektattribute."
+"In der Konfiguration der Objektattribute können Sie festlegen, ob ein Feld "
+"angezeigt wird und ob die Eingabe in das Feld verpflichtend ist, und zwar "
+"separat für verschiedene Ansichten und für verschiedene :doc:`Rollen/"
+"Berechtigungen </manage/roles/index>`."
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr "Screenshot zeigt Objektattribut-Berechtigungstabelle"
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
-"Bei Bedarf können Sie den Zugriff auf Objektattribute auf der Grundlage der :"
-"ref:`Benutzerrechte <permission-guide>` (``admin``, ``ticket.agent`` & "
-"``ticket.customer``) beschränken."
+"Einige der möglichen Berechtigungen und Ansichten für ein Attribut eines "
+"Benutzerobjekts."
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-"**🤓 Dies ist nicht die einzige Möglichkeit, die Verwendung zu beschränken**"
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
-"Sie können die folgenden Einstellungen jederzeit mit :doc:`/system/core-"
-"workflows` anpassen. Dies ermöglicht auch rollenbasierte Einschränkungen."
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
-msgstr ""
-"In manchen Situationen setzt Zammad intern die von Ihnen gewählten "
-"Einstellungen für Anzeige, Berechtigung und zu Pflichtfeldern außer Kraft. "
-"Dies betrifft Situationen, in denen ein Feld nicht gesetzt werden kann, das "
-"für die Erstellung eines Tickets erforderlich wäre."
+"Je nach Objektkontext (Ticket, Agent, Organisation, Benutzer) unterscheiden "
+"sich die auswählbaren Rollen (genauer gesagt: die erforderlichen "
+"Berechtigungen) und Ansichten. Beachten Sie, dass diese Einstellungen keinen "
+"Einfluss auf die Datenerstellung über andere Kanäle als die "
+"Benutzeroberfläche haben."
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr "Dies betrifft derzeit:"
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr "Zusammenfassen"
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
-msgstr "E-Mails, unabhängig vom Kanal (eingehend)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
+msgstr ""
+"Wenn Sie weitere Anpassungsmöglichkeiten brauchen, sollten Sie einen Blick "
+"in die :doc:`Core Workflows </system/core-workflows>` werfen."
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ":doc:`/channels/form` (eingehend)"
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
-msgstr ":doc:`/channels/facebook` (eingehend)"
+msgid "Screens"
+msgstr "Ansichten"
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ":doc:`/channels/telegram` (eingehend)"
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ":doc:`/channels/twitter-x/twitter` (eingehend)"
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr "SMS (eingehend)"
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
-msgstr "Über Ansichten"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
+msgstr ""
+"In der folgenden Tabelle finden Sie eine Übersicht über die verschiedenen "
+"Berechtigungen und die verfügbaren Ansichten, die Zammad unterscheidet."
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
-msgstr ""
-"Zammad unterscheidet zwischen mehreren Ansichten, in denen Objektattribute "
-"verwendet werden können."
+msgid "Screen"
+msgstr "Ansicht"
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr "Verfügbar für"
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr "create"
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
-msgstr ""
-"Jedes Mal, wenn Sie den Erstell-Dialog für noch nicht vorhandene Daten "
-"verwenden."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
+msgstr "admin.user"
+
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr "admin.organization"
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+msgid "admin.group"
+msgstr "admin.group"
+
+#: ../system/objects/permissions.rst:44
+msgid "Creation dialog for not yet existing data"
+msgstr "Erstellungsdialog für noch nicht vorhandene Daten"
 
 #: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr "create_middle"
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+msgid "ticket.customer"
+msgstr "ticket.customer"
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+msgid "ticket.agent"
+msgstr "ticket.agent"
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr "Ticket-Erstellungsdialog (mittlerer Bereich)"
+
+#: ../system/objects/permissions.rst:49
 msgid "edit"
 msgstr "edit"
 
-#: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
-msgstr ""
-"Jedes Mal, wenn Sie vorhandene Daten bearbeiten - die Anzeige vorhandener "
-"Tickets zählt als Bearbeitungsansicht."
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
+msgstr "Bearbeitungsdialog für bereits vorhandene Daten"
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr "Ansicht"
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-"Beeinflusst die Ansicht von bestehenden Daten wie z.B. Benutzerprofilen."
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr "Diese Einstellung ist in folgenden Objektkontexten verfügbar:"
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr "invite_customer & invite_agent"
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-"Wird angezeigt, wenn Sie den Einladungsdialog unter \"Erste Schritte\" im "
-"Dashboard verwenden."
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
-msgstr "Über Anzeigeoptionen"
+msgid "View-only dialog for already existing data"
+msgstr "Lese-Ansicht für bereits vorhandene Daten"
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
-msgstr ""
-"Da wir nun die verschiedenen möglichen Situationen kennen, sollten wir über "
-"die verfügbaren Optionen sprechen."
+msgid "(e.g. user or organization from search)"
+msgstr "(z.B. Benutzer oder Organisation über die Suche)"
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr "signup"
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
+msgstr "Anmelde-Ansicht für neue Kunden"
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr "anzeigen"
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-"Ein Feld anzeigen (Checkbox gefüllt) oder ausblenden (Checkbox nicht "
-"gefüllt)."
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
-msgstr "erforderlich"
+msgid "invite_customer"
+msgstr "invite_customer"
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
 msgstr ""
-"Setzen Sie ein Feld als erforderlich (Checkbox gefüllt). Zwingt Benutzer "
-"(über UI und API), das Feld auszufüllen."
+"Ansicht zur Einladung von Kunden (aus dem Bereich :doc:`Erste Schritte </"
+"misc/first-steps>`)"
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr "invite_agent"
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+"Ansicht für die Einladung von Agenten (aus dem Bereich :doc:`Erste Schritte "
+"</misc/first-steps>`)"
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr "Ansicht Optionen"
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+"Für die verschiedenen Ansichten können Sie die Optionen \"anzeigen\" und "
+"\"erforderlich\" auswählen."
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+"**Anzeigen:** Ein Feld anzeigen (Haken gesetzt) oder ausblenden (Haken nicht "
+"gesetzt)."
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
+msgstr ""
+"**Erforderlich:** Setzen Sie ein Feld auf erforderlich (Haken gesetzt), um "
+"eine Eingabe (über UI und API) zu erzwingen."
 
 #: ../system/objects/types.rst:7
 msgid "Example external data source"
@@ -32311,6 +32325,108 @@ msgid "Shows which version is currently being used on your Zammad-instance."
 msgstr ""
 "Zeigt an, welche Version derzeit auf Ihrer Zammad-Instanz verwendet wird."
 
+#~ msgid ""
+#~ "Whenever needed you can restrict access to attributes based on the :ref:"
+#~ "`user permission <permission-guide>` (``admin``, ``ticket.agent`` & "
+#~ "``ticket.customer``)."
+#~ msgstr ""
+#~ "Bei Bedarf können Sie den Zugriff auf Objektattribute auf der Grundlage "
+#~ "der :ref:`Benutzerrechte <permission-guide>` (``admin``, ``ticket.agent`` "
+#~ "& ``ticket.customer``) beschränken."
+
+#~ msgid "**🤓 This is not the only possibility to restrict access**"
+#~ msgstr ""
+#~ "**🤓 Dies ist nicht die einzige Möglichkeit, die Verwendung zu "
+#~ "beschränken**"
+
+#~ msgid ""
+#~ "You can always adjust below settings with :doc:`/system/core-workflows`. "
+#~ "This also allows role based restriction."
+#~ msgstr ""
+#~ "Sie können die folgenden Einstellungen jederzeit mit :doc:`/system/core-"
+#~ "workflows` anpassen. Dies ermöglicht auch rollenbasierte Einschränkungen."
+
+#~ msgid ""
+#~ "In some situations, Zammad internally overrules your chosen settings for "
+#~ "screen, requirement and permission. This affects situations where a field "
+#~ "can't be set which would be required for the ticket creation."
+#~ msgstr ""
+#~ "In manchen Situationen setzt Zammad intern die von Ihnen gewählten "
+#~ "Einstellungen für Anzeige, Berechtigung und zu Pflichtfeldern außer "
+#~ "Kraft. Dies betrifft Situationen, in denen ein Feld nicht gesetzt werden "
+#~ "kann, das für die Erstellung eines Tickets erforderlich wäre."
+
+#~ msgid "This currently affects:"
+#~ msgstr "Dies betrifft derzeit:"
+
+#~ msgid "merging"
+#~ msgstr "Zusammenfassen"
+
+#~ msgid "emails no matter of the originating channel (incoming)"
+#~ msgstr "E-Mails, unabhängig vom Kanal (eingehend)"
+
+#~ msgid ":doc:`/channels/form` (incoming)"
+#~ msgstr ":doc:`/channels/form` (eingehend)"
+
+#~ msgid ":doc:`/channels/facebook` (incoming)"
+#~ msgstr ":doc:`/channels/facebook` (eingehend)"
+
+#~ msgid ":doc:`/channels/telegram` (incoming)"
+#~ msgstr ":doc:`/channels/telegram` (eingehend)"
+
+#~ msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
+#~ msgstr ":doc:`/channels/twitter-x/twitter` (eingehend)"
+
+#~ msgid "SMS (incoming)"
+#~ msgstr "SMS (eingehend)"
+
+#~ msgid "About screens"
+#~ msgstr "Über Ansichten"
+
+#~ msgid ""
+#~ "Zammad differentiates between several screens where object attributes can "
+#~ "be used."
+#~ msgstr ""
+#~ "Zammad unterscheidet zwischen mehreren Ansichten, in denen "
+#~ "Objektattribute verwendet werden können."
+
+#~ msgid ""
+#~ "Every time you're editing existing data - viewing existing tickets counts "
+#~ "as edit screen."
+#~ msgstr ""
+#~ "Jedes Mal, wenn Sie vorhandene Daten bearbeiten - die Anzeige vorhandener "
+#~ "Tickets zählt als Bearbeitungsansicht."
+
+#~ msgid "Affects view screens of existing data like e.g. user profiles."
+#~ msgstr ""
+#~ "Beeinflusst die Ansicht von bestehenden Daten wie z.B. Benutzerprofilen."
+
+#~ msgid "This setting is available for the following object contexts:"
+#~ msgstr "Diese Einstellung ist in folgenden Objektkontexten verfügbar:"
+
+#~ msgid "invite_customer & invite_agent"
+#~ msgstr "invite_customer & invite_agent"
+
+#~ msgid ""
+#~ "Shown when using the invitation dialogue from \"First Steps\" in the "
+#~ "dashboard."
+#~ msgstr ""
+#~ "Wird angezeigt, wenn Sie den Einladungsdialog unter \"Erste Schritte\" im "
+#~ "Dashboard verwenden."
+
+#~ msgid ""
+#~ "Now that we know the different possible situations, let's talk about "
+#~ "available options."
+#~ msgstr ""
+#~ "Da wir nun die verschiedenen möglichen Situationen kennen, sollten wir "
+#~ "über die verfügbaren Optionen sprechen."
+
+#~ msgid "shown"
+#~ msgstr "anzeigen"
+
+#~ msgid "required"
+#~ msgstr "erforderlich"
+
 #~ msgid "Basic object conditions"
 #~ msgstr "Standard Bedingungen für Objekte"
 
@@ -32468,9 +32584,6 @@ msgstr ""
 #~ "Kunde das Ticket aktualisiert, ist es einer der Benutzer. Wenn es sich "
 #~ "nicht um eine menschliche Interaktion handelt, verwendet Zammad den "
 #~ "Systembenutzer. Dies kann zu unerwarteten Ergebnissen führen!*"
-
-#~ msgid "*Select one or more customers*"
-#~ msgstr "*Wählen Sie einen oder mehrere Kunden*"
 
 #~ msgid "Existing members *(Scope: Organization)*"
 #~ msgstr "Bestehende Mitglieder *(Bezug: Organisation)*"

--- a/locale/es/LC_MESSAGES/admin-docs.po
+++ b/locale/es/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: 2024-06-02 23:00+0000\n"
 "Last-Translator: Jordi Ferri <ferri1989@gmail.com>\n"
 "Language-Team: Spanish <https://translations.zammad.org/projects/"
@@ -615,8 +615,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr "Usuario"
 
@@ -2883,7 +2882,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr "Descripción"
 
@@ -10672,7 +10672,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13325,7 +13324,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13360,7 +13359,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22709,146 +22707,176 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
-msgstr ""
+#, fuzzy
+#| msgid "Version"
+msgid "Attribute Permissions"
+msgstr "Versión"
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+#, fuzzy
+#| msgid "Screenshot showing basic email account setup inbound"
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+"Captura de pantalla que muestra la configuración básica de una cuenta de "
+"correo electrónico entrante"
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
+msgstr ""
+
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+#, fuzzy
+msgid "admin.organization"
+msgstr "Ticket > Organización > Nota"
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+#, fuzzy
+#| msgid "group"
+msgid "admin.group"
+msgstr "grupo"
+
+#: ../system/objects/permissions.rst:44
+msgid "Creation dialog for not yet existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+#, fuzzy
+#| msgid "``#{ticket.customer.web}``"
+msgid "ticket.customer"
+msgstr "``#{ticket.customer.web}``"
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+#, fuzzy
+#| msgid "Ticket > #"
+msgid "ticket.agent"
+msgstr "Ticket > #"
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
 msgid "edit"
 msgstr ""
 
-#: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/es_CO/LC_MESSAGES/admin-docs.po
+++ b/locale/es_CO/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -499,8 +499,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr ""
 
@@ -2759,7 +2758,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr ""
 
@@ -10509,7 +10509,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13150,7 +13149,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13185,7 +13184,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22484,146 +22482,163 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr ""
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
 msgstr ""
 
-#: ../system/objects/permissions.rst:45
-msgid "edit"
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr ""
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+msgid "admin.group"
 msgstr ""
 
 #: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+msgid "Creation dialog for not yet existing data"
+msgstr ""
+
+#: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+msgid "ticket.customer"
+msgstr ""
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+msgid "ticket.agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
+msgid "edit"
+msgstr ""
+
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/es_MX/LC_MESSAGES/admin-docs.po
+++ b/locale/es_MX/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: 2023-10-11 14:18+0000\n"
 "Last-Translator: morealedgar <morealedgar@gmail.com>\n"
 "Language-Team: Spanish (Mexico) <https://translations.zammad.org/projects/"
@@ -502,8 +502,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr ""
 
@@ -2762,7 +2761,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr ""
 
@@ -10512,7 +10512,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13153,7 +13152,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13188,7 +13187,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22487,146 +22485,163 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr ""
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
 msgstr ""
 
-#: ../system/objects/permissions.rst:45
-msgid "edit"
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr ""
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+msgid "admin.group"
 msgstr ""
 
 #: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+msgid "Creation dialog for not yet existing data"
+msgstr ""
+
+#: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+msgid "ticket.customer"
+msgstr ""
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+msgid "ticket.agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
+msgid "edit"
+msgstr ""
+
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/fa/LC_MESSAGES/admin-docs.po
+++ b/locale/fa/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -499,8 +499,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr ""
 
@@ -2759,7 +2758,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr ""
 
@@ -10509,7 +10509,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13150,7 +13149,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13185,7 +13184,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22484,146 +22482,163 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr ""
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
 msgstr ""
 
-#: ../system/objects/permissions.rst:45
-msgid "edit"
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr ""
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+msgid "admin.group"
 msgstr ""
 
 #: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+msgid "Creation dialog for not yet existing data"
+msgstr ""
+
+#: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+msgid "ticket.customer"
+msgstr ""
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+msgid "ticket.agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
+msgid "edit"
+msgstr ""
+
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/fr/LC_MESSAGES/admin-docs.po
+++ b/locale/fr/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: 2024-07-09 00:00+0000\n"
 "Last-Translator: Guy S <guy@bilog.fr>\n"
 "Language-Team: French <https://translations.zammad.org/projects/"
@@ -645,8 +645,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr "Utilisateur"
 
@@ -2949,7 +2948,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr ""
 
@@ -10738,7 +10738,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr "Organisation"
 
@@ -13392,7 +13391,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 #, fuzzy
 msgid "Introduction"
 msgstr "Intégrations"
@@ -13430,7 +13429,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr "Groupe"
 
@@ -22789,146 +22787,180 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
-msgstr ""
+#, fuzzy
+#| msgid "Sessions"
+msgid "Attribute Permissions"
+msgstr "Sessions"
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+#, fuzzy
+#| msgid "Screenshot showing basic email account setup inbound"
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+"Capture d'écran montrant la configuration de base d'une boîte de réception"
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+#, fuzzy
+#| msgid "variable"
+msgid "Available for"
+msgstr "variable"
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
+msgstr ""
+
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+#, fuzzy
+#| msgid "Organization"
+msgid "admin.organization"
+msgstr "Organisation"
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+#, fuzzy
+#| msgid "group"
+msgid "admin.group"
+msgstr "groupe"
+
+#: ../system/objects/permissions.rst:44
+msgid "Creation dialog for not yet existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+#, fuzzy
+#| msgid "Customer"
+msgid "ticket.customer"
+msgstr "Client"
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+#, fuzzy
+msgid "ticket.agent"
+msgstr "priorité"
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
 msgid "edit"
 msgstr ""
 
-#: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
-msgstr ""
+#, fuzzy
+#| msgid "Customer"
+msgid "invite_customer"
+msgstr "Client"
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+#, fuzzy
+msgid "Screen Options"
+msgstr "Sociétés"
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/fr_CA/LC_MESSAGES/admin-docs.po
+++ b/locale/fr_CA/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: 2021-12-03 14:33+0000\n"
 "Last-Translator: TRANSFER FROM TRANSIFEX <support@zammad.com>\n"
 "Language-Team: French (Canada) <https://translations.zammad.org/projects/"
@@ -559,8 +559,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr ""
 
@@ -2942,7 +2941,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr ""
 
@@ -10750,7 +10750,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13409,7 +13408,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 #, fuzzy
 msgid "Introduction"
 msgstr "Bloquer les notifications"
@@ -13447,7 +13446,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22915,146 +22913,170 @@ msgstr ""
 
 #: ../system/objects/permissions.rst:2
 #, fuzzy
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr "Attributs d'article"
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+#, fuzzy
+#| msgid "variable"
+msgid "Available for"
+msgstr "Variable"
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
 msgstr ""
 
-#: ../system/objects/permissions.rst:45
-msgid "edit"
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+#, fuzzy
+msgid "admin.organization"
+msgstr "Billet > Organisation > Note"
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+msgid "admin.group"
 msgstr ""
 
 #: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+msgid "Creation dialog for not yet existing data"
+msgstr ""
+
+#: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+#, fuzzy
+#| msgid "The agent will be set as ticket customer."
+msgid "ticket.customer"
+msgstr "L'agent sera défini comme client du billet."
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+#, fuzzy
+#| msgid "Ticket"
+msgid "ticket.agent"
+msgstr "Billet"
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
+msgid "edit"
+msgstr ""
+
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/hr/LC_MESSAGES/admin-docs.po
+++ b/locale/hr/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: 2022-06-15 13:40+0000\n"
 "Last-Translator: Ivan Perovic <ip@zammad.com>\n"
 "Language-Team: Croatian <https://translations.zammad.org/projects/"
@@ -588,8 +588,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr ""
 
@@ -2849,7 +2848,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr "Opis"
 
@@ -10613,7 +10613,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13260,7 +13259,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13295,7 +13294,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22616,146 +22614,167 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr ""
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
+msgstr ""
+
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr ""
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+#, fuzzy
+#| msgid "group"
+msgid "admin.group"
+msgstr "grupa"
+
+#: ../system/objects/permissions.rst:44
+msgid "Creation dialog for not yet existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+#, fuzzy
+msgid "ticket.customer"
+msgstr "Makro-naredbe"
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+#, fuzzy
+msgid "ticket.agent"
+msgstr "Makro-naredbe"
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
 msgid "edit"
 msgstr ""
 
-#: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/hu/LC_MESSAGES/admin-docs.po
+++ b/locale/hu/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -499,8 +499,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr ""
 
@@ -2759,7 +2758,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr ""
 
@@ -10509,7 +10509,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13150,7 +13149,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13185,7 +13184,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22484,146 +22482,163 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr ""
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
 msgstr ""
 
-#: ../system/objects/permissions.rst:45
-msgid "edit"
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr ""
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+msgid "admin.group"
 msgstr ""
 
 #: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+msgid "Creation dialog for not yet existing data"
+msgstr ""
+
+#: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+msgid "ticket.customer"
+msgstr ""
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+msgid "ticket.agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
+msgid "edit"
+msgstr ""
+
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/it/LC_MESSAGES/admin-docs.po
+++ b/locale/it/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: 2023-04-15 10:17+0000\n"
 "Last-Translator: crnfpp <crnfpp@unife.it>\n"
 "Language-Team: Italian <https://translations.zammad.org/projects/"
@@ -520,8 +520,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr ""
 
@@ -2780,7 +2779,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr ""
 
@@ -10539,7 +10539,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13181,7 +13180,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13216,7 +13215,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22519,146 +22517,165 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr ""
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
 msgstr ""
 
-#: ../system/objects/permissions.rst:45
-msgid "edit"
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr ""
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+msgid "admin.group"
 msgstr ""
 
 #: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+msgid "Creation dialog for not yet existing data"
+msgstr ""
+
+#: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+#, fuzzy
+msgid "ticket.customer"
+msgstr "Macros"
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+#, fuzzy
+msgid "ticket.agent"
+msgstr "Macros"
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
+msgid "edit"
+msgstr ""
+
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/nl/LC_MESSAGES/admin-docs.po
+++ b/locale/nl/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -499,8 +499,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr ""
 
@@ -2759,7 +2758,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr ""
 
@@ -10509,7 +10509,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13150,7 +13149,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13185,7 +13184,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22484,146 +22482,163 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr ""
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
 msgstr ""
 
-#: ../system/objects/permissions.rst:45
-msgid "edit"
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr ""
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+msgid "admin.group"
 msgstr ""
 
 #: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+msgid "Creation dialog for not yet existing data"
+msgstr ""
+
+#: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+msgid "ticket.customer"
+msgstr ""
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+msgid "ticket.agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
+msgid "edit"
+msgstr ""
+
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/pl/LC_MESSAGES/admin-docs.po
+++ b/locale/pl/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: 2024-06-20 06:00+0000\n"
 "Last-Translator: MBekspert <michal.bosak@ekspert.biz>\n"
 "Language-Team: Polish <https://translations.zammad.org/projects/"
@@ -503,8 +503,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr ""
 
@@ -2763,7 +2762,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 #, fuzzy
 msgid "Description"
 msgstr "Opis"
@@ -10520,7 +10520,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13162,7 +13161,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13197,7 +13196,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22507,146 +22505,167 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr ""
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
+msgstr ""
+
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr ""
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+#, fuzzy
+#| msgid "group"
+msgid "admin.group"
+msgstr "grupa"
+
+#: ../system/objects/permissions.rst:44
+msgid "Creation dialog for not yet existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+#, fuzzy
+msgid "ticket.customer"
+msgstr "Makra"
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+#, fuzzy
+msgid "ticket.agent"
+msgstr "Makra"
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
 msgid "edit"
 msgstr ""
 
-#: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/pt_BR/LC_MESSAGES/admin-docs.po
+++ b/locale/pt_BR/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: 2024-03-10 08:00+0000\n"
 "Last-Translator: Glauber Daniel Ribeiro <glauberdribeiro@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://translations.zammad.org/projects/"
@@ -579,8 +579,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr "Usuário"
 
@@ -2865,7 +2864,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr "Descrição"
 
@@ -10765,7 +10765,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr "Organização"
 
@@ -13439,7 +13438,7 @@ msgstr "Permissões de objetos"
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 #, fuzzy
 msgid "Introduction"
 msgstr "Integrações"
@@ -13477,7 +13476,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr "Grupo"
 
@@ -22926,146 +22924,170 @@ msgstr ""
 
 #: ../system/objects/permissions.rst:2
 #, fuzzy
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr "Atributos do artigo"
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
-msgstr ""
+#, fuzzy
+msgid "Screens"
+msgstr "Assinaturas"
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+#, fuzzy
+msgid "Screen"
+msgstr "Assinaturas"
+
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
 msgstr ""
 
-#: ../system/objects/permissions.rst:45
-msgid "edit"
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+#, fuzzy
+#| msgid "Organization"
+msgid "admin.organization"
+msgstr "Organização"
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+msgid "admin.group"
 msgstr ""
 
 #: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+msgid "Creation dialog for not yet existing data"
+msgstr ""
+
+#: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+#, fuzzy
+msgid "ticket.customer"
+msgstr "Criar uma macro global"
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+#, fuzzy
+msgid "ticket.agent"
+msgstr "Criar uma macro global"
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
+msgid "edit"
+msgstr ""
+
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+#, fuzzy
+msgid "Screen Options"
+msgstr "Organizações"
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/ru/LC_MESSAGES/admin-docs.po
+++ b/locale/ru/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: 2024-08-06 03:16+0000\n"
 "Last-Translator: Nikita <nyakovlev@iko.tech>\n"
 "Language-Team: Russian <https://translations.zammad.org/projects/"
@@ -532,8 +532,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr ""
 
@@ -2792,7 +2791,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr ""
 
@@ -10542,7 +10542,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13183,7 +13182,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13218,7 +13217,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22523,146 +22521,167 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr ""
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
 msgstr ""
 
-#: ../system/objects/permissions.rst:45
-msgid "edit"
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr ""
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+msgid "admin.group"
 msgstr ""
 
 #: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+msgid "Creation dialog for not yet existing data"
+msgstr ""
+
+#: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+#, fuzzy
+#| msgid "Ticket Macros"
+msgid "ticket.customer"
+msgstr "Макрос заявки"
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+#, fuzzy
+#| msgid "Ticket Macros"
+msgid "ticket.agent"
+msgstr "Макрос заявки"
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
+msgid "edit"
+msgstr ""
+
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/sr/LC_MESSAGES/admin-docs.po
+++ b/locale/sr/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad Admin Documentation pre-release\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: 2024-08-13 08:00+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
@@ -598,8 +598,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr "Корисник"
 
@@ -3308,7 +3307,8 @@ msgstr "Подразумевана вредност"
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr "Опис"
 
@@ -7174,7 +7174,8 @@ msgstr ""
 
 #: ../manage/checklist.rst:None
 msgid "Screenshot showing the checklist template edit dialog."
-msgstr "Снимак екрана који приказује дијалог уређивања шаблона списка задатака."
+msgstr ""
+"Снимак екрана који приказује дијалог уређивања шаблона списка задатака."
 
 #: ../manage/checklist.rst:39
 msgid "Remarks"
@@ -12711,7 +12712,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr "Организација"
 
@@ -15936,7 +15936,7 @@ msgstr "Услови објекта"
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr "Увод"
 
@@ -15983,7 +15983,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr "Група"
 
@@ -27353,164 +27352,215 @@ msgstr ""
 "templates>`."
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+#, fuzzy
+#| msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr "Дозволе атрибута"
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
+#, fuzzy
+#| msgid "Screenshot showing translatable attribute types"
+msgid "Screenshot shows object attribute permission table"
+msgstr "Снимак екрана који приказује типове атрибута који се могу превести"
+
+#: ../system/objects/permissions.rst:17
+#, fuzzy
+#| msgid ""
+#| "Some of the possible permissions and screen options for object attributes."
+msgid ""
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr "Неке од могућих дозвола и опција страна за атрибуте објекта."
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:19
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
-"Кад год је потребно да ограничите приступ атрибутима на основу :ref:`дозвола "
-"корисника <permission-guide>` (``admin``, ``ticket.agent`` и ``ticket."
-"customer``)."
-
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr "**🤓 Ово није једини начин да ограничите приступ**"
-
-#: ../system/objects/permissions.rst:15
-msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-"Доња подешавања можете увек поставити уз помоћ :doc:`радних токова </system/"
-"core-workflows>`. Ово такође омогућава ограничавање на основу улога."
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
-msgstr ""
-"У неким ситуацијама, Zammad ће интерно преиначити доњи екран, обавезност "
-"поља и подешавања дозвола. Ово се дешава јер у неким тренуцима нисте у "
-"могућности да поставите обавезна поља што може резултовати у не отварању "
-"тикета."
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr "Ово тренутно утиче на:"
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr "спајање"
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
-msgstr "имејлове без обзира на долазни канал"
+#, fuzzy
+#| msgid ""
+#| "If you even further want to configure what your customers can see and "
+#| "select, you should have a look in our :doc:`/system/core-workflows` "
+#| "documentation."
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
+msgstr ""
+"Уколико желите да подесите шта ваши клијенти могу да виде и одаберу, "
+"погледајте документацију :doc:`радних токова </system/core-workflows>`."
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ":doc:`форме </channels/form>` (долазне)"
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
-msgstr ":doc:`/channels/facebook` (долазне)"
+#, fuzzy
+#| msgid "Login Screen"
+msgid "Screens"
+msgstr "Страна за пријављивање"
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ":doc:`/channels/telegram` (долазне)"
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ":doc:`/channels/twitter-x/twitter` (долазне)"
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr "SMS (долазне)"
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
-msgstr "О странама"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
+msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
-msgstr ""
-"Zammad прави разлику између неколико страна где је могуће користити атрибуте "
-"објекта."
+#, fuzzy
+#| msgid "Login Screen"
+msgid "Screen"
+msgstr "Страна за пријављивање"
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+#, fuzzy
+#| msgid "Available Operators"
+msgid "Available for"
+msgstr "Доступни оператори"
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr "create"
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+#, fuzzy
+#| msgid "``admin.user``"
+msgid "admin.user"
+msgstr "``admin.user``"
+
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+#, fuzzy
+#| msgid "``admin.organization``"
+msgid "admin.organization"
+msgstr "``admin.organization``"
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+#, fuzzy
+#| msgid "``admin.group``"
+msgid "admin.group"
+msgstr "``admin.group``"
+
+#: ../system/objects/permissions.rst:44
+#, fuzzy
+#| msgid "Every time you use a creation dialogue for not yet existing data."
+msgid "Creation dialog for not yet existing data"
 msgstr ""
 "Сваки пут кад користите дијалог за отварања или додавање података који још "
 "увек не постоје."
 
 #: ../system/objects/permissions.rst:45
+#, fuzzy
+#| msgid "created"
+msgid "create_middle"
+msgstr "додато"
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+#, fuzzy
+#| msgid "``ticket.customer``"
+msgid "ticket.customer"
+msgstr "``ticket.customer``"
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+#, fuzzy
+#| msgid "``ticket.agent``"
+msgid "ticket.agent"
+msgstr "``ticket.agent``"
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
 msgid "edit"
 msgstr "edit"
 
-#: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+#: ../system/objects/permissions.rst:55
+#, fuzzy
+#| msgid "Every time you use a creation dialogue for not yet existing data."
+msgid "Editing dialog for already existing data"
 msgstr ""
-"Сваки пут када уређујете постојеће податке – преглед постојећих тикета се "
-"рачуна као edit страна."
+"Сваки пут кад користите дијалог за отварања или додавање података који још "
+"увек не постоје."
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr "view"
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr "Односи се стране прегледа постојећих података нпр. корисничке профиле."
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr "Ово подешавање је омогућено за следеће контексте објеката:"
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr "invite_customer и invite_agent"
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-"Приказано у дијалогу позивнице из одељка „Први кораци” на контролној табли."
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
-msgstr "О опцијама страна"
+msgid "View-only dialog for already existing data"
+msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
 msgstr ""
-"Сада када разумете различите могуће ситуације, хајде да попричамо о "
-"доступним опцијама."
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+#, fuzzy
+#| msgid "*Select one or more customers*"
+msgid "Sign-up screen for new customers"
+msgstr "*Изаберите једног или више клијената*"
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr "приказано"
+#, fuzzy
+#| msgid "customer"
+msgid "invite_customer"
+msgstr "customer"
 
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
+#: ../system/objects/permissions.rst:71
+msgid ""
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+#, fuzzy
+#| msgid "About screen options"
+msgid "Screen Options"
+msgstr "О опцијама страна"
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+#, fuzzy
+#| msgid "Show (checked) or hide (unchecked) a field."
+msgid "**shown:** Show (check) or hide (uncheck) a field."
 msgstr "Прикажи (чекирано) или сакриј (нечекирано) поље."
 
-#: ../system/objects/permissions.rst:71
-msgid "required"
-msgstr "обавезно"
-
-#: ../system/objects/permissions.rst:71
+#: ../system/objects/permissions.rst:83
+#, fuzzy
+#| msgid ""
+#| "Set a field to mandatory (checked). Forces users (via UI and API) to "
+#| "populate the field."
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 "Постављање поља на обавезно. Очекује од корисника да попуне поље (путем "
 "корисничког интерфејса и API)."
@@ -31370,6 +31420,107 @@ msgstr "Верзија"
 msgid "Shows which version is currently being used on your Zammad-instance."
 msgstr "Приказује која верзија се користи тренутно на вашој Zammad инстанци."
 
+#~ msgid ""
+#~ "Whenever needed you can restrict access to attributes based on the :ref:"
+#~ "`user permission <permission-guide>` (``admin``, ``ticket.agent`` & "
+#~ "``ticket.customer``)."
+#~ msgstr ""
+#~ "Кад год је потребно да ограничите приступ атрибутима на основу :ref:"
+#~ "`дозвола корисника <permission-guide>` (``admin``, ``ticket.agent`` и "
+#~ "``ticket.customer``)."
+
+#~ msgid "**🤓 This is not the only possibility to restrict access**"
+#~ msgstr "**🤓 Ово није једини начин да ограничите приступ**"
+
+#~ msgid ""
+#~ "You can always adjust below settings with :doc:`/system/core-workflows`. "
+#~ "This also allows role based restriction."
+#~ msgstr ""
+#~ "Доња подешавања можете увек поставити уз помоћ :doc:`радних токова </"
+#~ "system/core-workflows>`. Ово такође омогућава ограничавање на основу "
+#~ "улога."
+
+#~ msgid ""
+#~ "In some situations, Zammad internally overrules your chosen settings for "
+#~ "screen, requirement and permission. This affects situations where a field "
+#~ "can't be set which would be required for the ticket creation."
+#~ msgstr ""
+#~ "У неким ситуацијама, Zammad ће интерно преиначити доњи екран, обавезност "
+#~ "поља и подешавања дозвола. Ово се дешава јер у неким тренуцима нисте у "
+#~ "могућности да поставите обавезна поља што може резултовати у не отварању "
+#~ "тикета."
+
+#~ msgid "This currently affects:"
+#~ msgstr "Ово тренутно утиче на:"
+
+#~ msgid "merging"
+#~ msgstr "спајање"
+
+#~ msgid "emails no matter of the originating channel (incoming)"
+#~ msgstr "имејлове без обзира на долазни канал"
+
+#~ msgid ":doc:`/channels/form` (incoming)"
+#~ msgstr ":doc:`форме </channels/form>` (долазне)"
+
+#~ msgid ":doc:`/channels/facebook` (incoming)"
+#~ msgstr ":doc:`/channels/facebook` (долазне)"
+
+#~ msgid ":doc:`/channels/telegram` (incoming)"
+#~ msgstr ":doc:`/channels/telegram` (долазне)"
+
+#~ msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
+#~ msgstr ":doc:`/channels/twitter-x/twitter` (долазне)"
+
+#~ msgid "SMS (incoming)"
+#~ msgstr "SMS (долазне)"
+
+#~ msgid "About screens"
+#~ msgstr "О странама"
+
+#~ msgid ""
+#~ "Zammad differentiates between several screens where object attributes can "
+#~ "be used."
+#~ msgstr ""
+#~ "Zammad прави разлику између неколико страна где је могуће користити "
+#~ "атрибуте објекта."
+
+#~ msgid ""
+#~ "Every time you're editing existing data - viewing existing tickets counts "
+#~ "as edit screen."
+#~ msgstr ""
+#~ "Сваки пут када уређујете постојеће податке – преглед постојећих тикета се "
+#~ "рачуна као edit страна."
+
+#~ msgid "Affects view screens of existing data like e.g. user profiles."
+#~ msgstr ""
+#~ "Односи се стране прегледа постојећих података нпр. корисничке профиле."
+
+#~ msgid "This setting is available for the following object contexts:"
+#~ msgstr "Ово подешавање је омогућено за следеће контексте објеката:"
+
+#~ msgid "invite_customer & invite_agent"
+#~ msgstr "invite_customer и invite_agent"
+
+#~ msgid ""
+#~ "Shown when using the invitation dialogue from \"First Steps\" in the "
+#~ "dashboard."
+#~ msgstr ""
+#~ "Приказано у дијалогу позивнице из одељка „Први кораци” на контролној "
+#~ "табли."
+
+#~ msgid ""
+#~ "Now that we know the different possible situations, let's talk about "
+#~ "available options."
+#~ msgstr ""
+#~ "Сада када разумете различите могуће ситуације, хајде да попричамо о "
+#~ "доступним опцијама."
+
+#~ msgid "shown"
+#~ msgstr "приказано"
+
+#~ msgid "required"
+#~ msgstr "обавезно"
+
 #~ msgid "Basic object conditions"
 #~ msgstr "Основни услови објекта"
 
@@ -31524,9 +31675,6 @@ msgstr "Приказује која верзија се користи трен�
 #~ "клијент освежава тикет, у питању је корисник. Ако ово није била људска "
 #~ "интеракција, Zammad ће користити системског корисника. Ово може имати "
 #~ "неочекиване резултате!*"
-
-#~ msgid "*Select one or more customers*"
-#~ msgstr "*Изаберите једног или више клијената*"
 
 #~ msgid "Existing members *(Scope: Organization)*"
 #~ msgstr "Постојећи чланови *(обим: организација)*"

--- a/locale/sv/LC_MESSAGES/admin-docs.po
+++ b/locale/sv/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: 2024-02-01 11:00+0000\n"
 "Last-Translator: kjellbrandes <kjell@zippit.se>\n"
 "Language-Team: Swedish <https://translations.zammad.org/projects/"
@@ -503,8 +503,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr ""
 
@@ -2763,7 +2762,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr ""
 
@@ -10513,7 +10513,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13154,7 +13153,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13189,7 +13188,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22488,146 +22486,163 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr ""
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
 msgstr ""
 
-#: ../system/objects/permissions.rst:45
-msgid "edit"
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr ""
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+msgid "admin.group"
 msgstr ""
 
 #: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+msgid "Creation dialog for not yet existing data"
+msgstr ""
+
+#: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+msgid "ticket.customer"
+msgstr ""
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+msgid "ticket.agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
+msgid "edit"
+msgstr ""
+
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/th/LC_MESSAGES/admin-docs.po
+++ b/locale/th/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -499,8 +499,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr ""
 
@@ -2759,7 +2758,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr ""
 
@@ -10509,7 +10509,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13150,7 +13149,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13185,7 +13184,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22484,146 +22482,163 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr ""
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
 msgstr ""
 
-#: ../system/objects/permissions.rst:45
-msgid "edit"
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr ""
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+msgid "admin.group"
 msgstr ""
 
 #: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+msgid "Creation dialog for not yet existing data"
+msgstr ""
+
+#: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+msgid "ticket.customer"
+msgstr ""
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+msgid "ticket.agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
+msgid "edit"
+msgstr ""
+
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7

--- a/locale/tr/LC_MESSAGES/admin-docs.po
+++ b/locale/tr/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: 2024-05-22 09:00+0000\n"
 "Last-Translator: Berkay Gökmen <berkaygokmen24@gmail.com>\n"
 "Language-Team: Turkish <https://translations.zammad.org/projects/"
@@ -598,8 +598,7 @@ msgstr ""
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr "Kullanıcı"
 
@@ -2963,7 +2962,8 @@ msgstr "Varsayılan değer"
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr "Açıklama"
 
@@ -11116,7 +11116,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13863,7 +13862,7 @@ msgstr "Nesne izinleri"
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 #, fuzzy
 msgid "Introduction"
 msgstr "Entegrasyonlar"
@@ -13901,7 +13900,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr "Grup"
 
@@ -23485,147 +23483,184 @@ msgstr ""
 
 #: ../system/objects/permissions.rst:2
 #, fuzzy
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr "Bilet Nitelikleri"
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+#, fuzzy
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+"Yönetici panelinin Makrolar sayfasında makro oluşturabilir veya "
+"düzenleyebilirsiniz:"
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
-msgstr ""
+#, fuzzy
+msgid "Screens"
+msgstr "İmzalar"
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-#, fuzzy
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ":doc:`Kanallar > Twitter </channels/twitter>`"
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
-msgstr ""
+#, fuzzy
+msgid "Screen"
+msgstr "İmzalar"
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+#, fuzzy
+#| msgid "variable"
+msgid "Available for"
+msgstr "değişken"
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+#, fuzzy
+#| msgid "``admin.user``"
+msgid "admin.user"
+msgstr "``admin.user``"
+
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+#, fuzzy
+#| msgid "``admin.organization``"
+msgid "admin.organization"
+msgstr "``admin.organization``"
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+#, fuzzy
+#| msgid "``admin.group``"
+msgid "admin.group"
+msgstr "``admin.group``"
+
+#: ../system/objects/permissions.rst:44
+msgid "Creation dialog for not yet existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:45
+#, fuzzy
+msgid "create_middle"
+msgstr "Oluşturulma"
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+#, fuzzy
+#| msgid "``#{ticket.customer.web}``"
+msgid "ticket.customer"
+msgstr "``#{ticket.customer.web}``"
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+#, fuzzy
+#| msgid "``ticket.agent``"
+msgid "ticket.agent"
+msgstr "``ticket.agent``"
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
 msgid "edit"
 msgstr ""
 
-#: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
-msgstr ""
+#, fuzzy
+#| msgid "customer"
+msgid "invite_customer"
+msgstr "müşteri"
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+#, fuzzy
+msgid "Screen Options"
+msgstr "Seçenek"
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7
@@ -27225,6 +27260,10 @@ msgstr "Versiyon"
 #: ../system/version.rst:4
 msgid "Shows which version is currently being used on your Zammad-instance."
 msgstr "Zammad örneğinizde şu anda hangi versiyonun kullanıldığını gösterir."
+
+#, fuzzy
+#~ msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
+#~ msgstr ":doc:`Kanallar > Twitter </channels/twitter>`"
 
 #, fuzzy
 #~ msgid "How they work"

--- a/locale/zh_Hans/LC_MESSAGES/admin-docs.po
+++ b/locale/zh_Hans/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-09 16:04+0200\n"
+"POT-Creation-Date: 2024-08-15 11:11+0200\n"
 "PO-Revision-Date: 2023-08-14 12:18+0000\n"
 "Last-Translator: chen <chenchen@4chian.com>\n"
 "Language-Team: Chinese (Simplified) <https://translations.zammad.org/"
@@ -576,8 +576,7 @@ msgstr "如果你不知道，请联系你的电子邮件提供商或系统管理
 #: ../channels/email/accounts/account-setup.rst:249
 #: ../channels/email/accounts/email-notification.rst:30
 #: ../misc/object-conditions/basics.rst:26
-#: ../settings/security/third-party/microsoft.rst:68
-#: ../system/objects/permissions.rst:54 ../system/sessions.rst:19
+#: ../settings/security/third-party/microsoft.rst:68 ../system/sessions.rst:19
 msgid "User"
 msgstr "用户"
 
@@ -2843,7 +2842,8 @@ msgstr ""
 #: ../channels/form.rst:219 ../manage/public-links.rst:47
 #: ../misc/object-conditions/basics.rst:64
 #: ../system/core-workflows/condition-operators.rst:21
-#: ../system/subscription/billing.rst:53 ../system/variables.rst:100
+#: ../system/objects/permissions.rst:39 ../system/subscription/billing.rst:53
+#: ../system/variables.rst:100
 msgid "Description"
 msgstr "描述"
 
@@ -10605,7 +10605,6 @@ msgstr ""
 #: ../manage/time-accounting.rst:190 ../misc/object-conditions/basics.rst:27
 #: ../misc/object-conditions/basics.rst:102
 #: ../misc/object-conditions/basics.rst:133 ../settings/branding.rst:13
-#: ../system/objects/permissions.rst:55
 msgid "Organization"
 msgstr ""
 
@@ -13248,7 +13247,7 @@ msgstr ""
 
 #: ../misc/object-conditions/basics.rst:5
 #: ../settings/security/ssl-certificates.rst:5
-#: ../system/integrations/pgp/index.rst:5
+#: ../system/integrations/pgp/index.rst:5 ../system/objects/permissions.rst:5
 msgid "Introduction"
 msgstr ""
 
@@ -13283,7 +13282,6 @@ msgstr ""
 #: ../misc/object-conditions/basics.rst:28
 #: ../misc/object-conditions/basics.rst:125
 #: ../system/integrations/checkmk/admin-panel-reference.rst:15
-#: ../system/objects/permissions.rst:56
 msgid "Group"
 msgstr ""
 
@@ -22602,146 +22600,167 @@ msgid ""
 msgstr ""
 
 #: ../system/objects/permissions.rst:2
-msgid "Attribute permissions"
+msgid "Attribute Permissions"
 msgstr ""
 
 #: ../system/objects/permissions.rst:7
 msgid ""
-"Some of the possible permissions and screen options for object attributes."
+"In the object attributes configuration you can define if a field is shown "
+"and if the input in the field is mandatory, separated by different screens "
+"and for different :doc:`roles/permissions </manage/roles/index>`."
 msgstr ""
 
-#: ../system/objects/permissions.rst:9
+#: ../system/objects/permissions.rst:17
+msgid "Screenshot shows object attribute permission table"
+msgstr ""
+
+#: ../system/objects/permissions.rst:17
 msgid ""
-"Whenever needed you can restrict access to attributes based on the :ref:"
-"`user permission <permission-guide>` (``admin``, ``ticket.agent`` & ``ticket."
-"customer``)."
+"Some of the possible permissions and screen options for a user object "
+"attribute."
 msgstr ""
 
-#: ../system/objects/permissions.rst:13
-msgid "**🤓 This is not the only possibility to restrict access**"
-msgstr ""
-
-#: ../system/objects/permissions.rst:15
+#: ../system/objects/permissions.rst:19
 msgid ""
-"You can always adjust below settings with :doc:`/system/core-workflows`. "
-"This also allows role based restriction."
-msgstr ""
-
-#: ../system/objects/permissions.rst:20
-msgid ""
-"In some situations, Zammad internally overrules your chosen settings for "
-"screen, requirement and permission. This affects situations where a field "
-"can't be set which would be required for the ticket creation."
+"Based on the object context (ticket, agent, organization, user), the "
+"selectable roles (to be precise: the required permissions) and screens "
+"differ. Be aware that these settings aren't affecting data creation via "
+"other channels than the UI."
 msgstr ""
 
 #: ../system/objects/permissions.rst:24
-msgid "This currently affects:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:26
-msgid "merging"
-msgstr ""
-
-#: ../system/objects/permissions.rst:27
-msgid "emails no matter of the originating channel (incoming)"
+msgid ""
+"If you want to have further customization possibilities, you should have a "
+"look at the :doc:`core workflows </system/core-workflows>`."
 msgstr ""
 
 #: ../system/objects/permissions.rst:28
-msgid ":doc:`/channels/form` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:29
-msgid ":doc:`/channels/facebook` (incoming)"
+msgid "Screens"
 msgstr ""
 
 #: ../system/objects/permissions.rst:30
-msgid ":doc:`/channels/telegram` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:31
-msgid ":doc:`/channels/twitter-x/twitter` (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:32
-msgid "SMS (incoming)"
-msgstr ""
-
-#: ../system/objects/permissions.rst:35
-msgid "About screens"
+msgid ""
+"In the table below you can find an overview about the different permissions "
+"and the available screens Zammad distinguishes between."
 msgstr ""
 
 #: ../system/objects/permissions.rst:37
-msgid ""
-"Zammad differentiates between several screens where object attributes can be "
-"used."
+msgid "Screen"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
+#: ../system/objects/permissions.rst:38
+msgid "Available for"
+msgstr ""
+
+#: ../system/objects/permissions.rst:40
 msgid "create"
 msgstr ""
 
-#: ../system/objects/permissions.rst:41
-msgid "Every time you use a creation dialogue for not yet existing data."
+#: ../system/objects/permissions.rst:41 ../system/objects/permissions.rst:52
+#: ../system/objects/permissions.rst:59 ../system/objects/permissions.rst:73
+msgid "admin.user"
+msgstr ""
+
+#: ../system/objects/permissions.rst:42 ../system/objects/permissions.rst:53
+#: ../system/objects/permissions.rst:60
+msgid "admin.organization"
+msgstr ""
+
+#: ../system/objects/permissions.rst:43 ../system/objects/permissions.rst:54
+#: ../system/objects/permissions.rst:61
+#, fuzzy
+#| msgid "group"
+msgid "admin.group"
+msgstr "组"
+
+#: ../system/objects/permissions.rst:44
+msgid "Creation dialog for not yet existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:45
+msgid "create_middle"
+msgstr ""
+
+#: ../system/objects/permissions.rst:46 ../system/objects/permissions.rst:50
+#: ../system/objects/permissions.rst:57 ../system/objects/permissions.rst:66
+#: ../system/objects/permissions.rst:70
+#, fuzzy
+msgid "ticket.customer"
+msgstr "宏"
+
+#: ../system/objects/permissions.rst:47 ../system/objects/permissions.rst:51
+#: ../system/objects/permissions.rst:58 ../system/objects/permissions.rst:69
+#, fuzzy
+msgid "ticket.agent"
+msgstr "宏"
+
+#: ../system/objects/permissions.rst:48
+msgid "Ticket create dialog (middle section)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:49
 msgid "edit"
 msgstr ""
 
-#: ../system/objects/permissions.rst:44
-msgid ""
-"Every time you're editing existing data - viewing existing tickets counts as "
-"edit screen."
+#: ../system/objects/permissions.rst:55
+msgid "Editing dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:56
 msgid "view"
 msgstr ""
 
-#: ../system/objects/permissions.rst:48
-msgid "Affects view screens of existing data like e.g. user profiles."
-msgstr ""
-
-#: ../system/objects/permissions.rst:52
-msgid "This setting is available for the following object contexts:"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid "invite_customer & invite_agent"
-msgstr ""
-
-#: ../system/objects/permissions.rst:59
-msgid ""
-"Shown when using the invitation dialogue from \"First Steps\" in the "
-"dashboard."
-msgstr ""
-
 #: ../system/objects/permissions.rst:62
-msgid "About screen options"
+msgid "View-only dialog for already existing data"
 msgstr ""
 
 #: ../system/objects/permissions.rst:64
-msgid ""
-"Now that we know the different possible situations, let's talk about "
-"available options."
+msgid "(e.g. user or organization from search)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:65
+msgid "signup"
+msgstr ""
+
+#: ../system/objects/permissions.rst:67
+msgid "Sign-up screen for new customers"
 msgstr ""
 
 #: ../system/objects/permissions.rst:68
-msgid "shown"
-msgstr ""
-
-#: ../system/objects/permissions.rst:68
-msgid "Show (checked) or hide (unchecked) a field."
-msgstr ""
-
-#: ../system/objects/permissions.rst:71
-msgid "required"
+msgid "invite_customer"
 msgstr ""
 
 #: ../system/objects/permissions.rst:71
 msgid ""
-"Set a field to mandatory (checked). Forces users (via UI and API) to "
-"populate the field."
+"Customer invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:72
+msgid "invite_agent"
+msgstr ""
+
+#: ../system/objects/permissions.rst:74
+msgid ""
+"Agent invitation screen (from :doc:`First Steps </misc/first-steps>` area)"
+msgstr ""
+
+#: ../system/objects/permissions.rst:78
+msgid "Screen Options"
+msgstr ""
+
+#: ../system/objects/permissions.rst:80
+msgid ""
+"For the different screens you can select \"show\" and \"required\" options."
+msgstr ""
+
+#: ../system/objects/permissions.rst:82
+msgid "**shown:** Show (check) or hide (uncheck) a field."
+msgstr ""
+
+#: ../system/objects/permissions.rst:83
+msgid ""
+"**required:** Set a field to mandatory (check). Forces users (via UI and "
+"API) to populate the field."
 msgstr ""
 
 #: ../system/objects/types.rst:7


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/Admin Documentation (pre-release)](https://translations.zammad.org/projects/documentations/admin-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/admin-documentation-pre-release/horizontal-auto.svg)