### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/cs/LC_MESSAGES/admin-docs.po
+++ b/locale/cs/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: 2023-09-23 01:11+0000\n"
 "Last-Translator: Tomáš Kovařík <tomas.kovarik@cdv.cz>\n"
 "Language-Team: Czech <https://translations.zammad.org/projects/"
@@ -1938,58 +1938,106 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+#, fuzzy
+#| msgid "Bad experiences"
+msgid "References"
+msgstr "Špatné zkušenosti"
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -1997,189 +2045,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2187,21 +2235,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "
@@ -26145,9 +26193,6 @@ msgstr ""
 
 #~ msgid "Solving my problem quickly"
 #~ msgstr "Rychlé řešení mých problémů"
-
-#~ msgid "Bad experiences"
-#~ msgstr "Špatné zkušenosti"
 
 #~ msgid ""
 #~ "A chat window on a website (while the chat being offline) with the hint "

--- a/locale/da/LC_MESSAGES/admin-docs.po
+++ b/locale/da/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1916,58 +1916,104 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+msgid "References"
+msgstr ""
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -1975,189 +2021,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2165,21 +2211,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "

--- a/locale/de/LC_MESSAGES/admin-docs.po
+++ b/locale/de/LC_MESSAGES/admin-docs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
-"PO-Revision-Date: 2024-08-22 07:00+0000\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
+"PO-Revision-Date: 2024-08-27 07:00+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
 "documentations/admin-documentation-pre-release/de/>\n"
@@ -2334,34 +2334,92 @@ msgstr ""
 "Diese E-Mail-Adresse wird für die Benachrichtigung von Agenten und zum "
 "Zurücksetzen des Passworts verwendet (betrifft hier ggf. auch Kunden)."
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
-msgstr "Erweiterte Nachfrage-Erkennung"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
+msgstr "Erweiterte Nachfrage-Erkennung: Standardwert ``Betreff & Referenzen``"
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
 msgstr ""
-"In manchen Szenarien ist die normale Nachfrage-Erkennung nicht ausreichend. "
-"Das kann beispielsweise sein, wenn im Betreff die Ticket-Referenz (Ticket-"
-"Hook und Nummer) fehlt. Das Einschalten dieser Option hilft, auch in solchen "
-"Fällen eine Zuordnung von E-Mails zu bestehenden Tickets zu bekommen."
+"Stellen Sie ein, wie Zammad prüft, ob eine eingehende E-Mail eine Nachfrage "
+"ist oder nicht. Wenn Sie alle Prüfungen deaktivieren, prüft Zammad nur, ob "
+"ein passender Ticket-Hook und eine Ticket-Nummer im Betreff vorhanden sind."
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
+msgstr "Betreff & Referenzen"
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
-"Bitte beachten Sie, dass die Suche im Anhang und im Text zu einer *falschen "
-"Erkennung von Nachfragen* führen kann."
+"Prüft die Betreff- und Nachrichten-IDs von E-Mails und sucht nach ersten "
+"Ticket-Artikeln mit demselben Betreff und derselben Nachrichten-ID. Wenn "
+"beide übereinstimmen, wird dies als Nachfrage betrachtet."
 
 #: ../channels/email/settings.rst:37
+msgid "References"
+msgstr "Referenzen"
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+"Prüft zusätzlich, ob eine ID aus einer E-Mail mit einem vorhandenen Artikel "
+"übereinstimmt."
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr "Anhang"
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+"Prüft zusätzlich Anhänge von E-Mails. Nützlich, wenn Sie häufig E-Mails als "
+"Anhang weitergeleitet bekommen und diese in bestehenden Tickets haben "
+"möchten, sofern eine Referenz in einer angehängten E-Mail enthalten ist."
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr "Body"
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+"Zusätzlich wird der Body von E-Mails überprüft. Wenn der Body eine Ticket-"
+"Kennung (Ticket-Hook und -Nummer) enthält, wird die E-Mail als Nachfrage "
+"betrachtet. Nützlich, wenn Sie E-Mails zu bestehenden Tickets hinzufügen "
+"möchten, die völlig unabhängig sind, sich aber auf bestehende Tickets "
+"beziehen und eine solche Ticket-Referenz enthalten."
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+"Bitte beachten Sie, dass die Aktivierung zusätzlicher Prüfungen zu einer "
+"falschen Erkennung führen kann. In Produktionsumgebungen sollten Sie diese "
+"Einstellung sehr vorsichtig ändern und das Verhalten anschließend überwachen."
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr "Maximale E-Mail-Größe: Standardwert ``10 MB``"
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
@@ -2371,17 +2429,17 @@ msgstr ""
 "abrufen wird. Zammad wird keine E-Mails abrufen, die größer als der "
 "angegebene Wert sind."
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 "Senden einer Postmaster-E-Mail, wenn die E-Mail zu groß ist: Standardwert "
 "``ja``"
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr "Option ist auf ``ja`` gesetzt"
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
@@ -2391,16 +2449,17 @@ msgstr ""
 "verschicken, sofern E-Mails die Größenbegrenzung überschreiten. Das gibt den "
 "Kunden die Möglichkeit, die E-Mail erneut zu senden (mit reduzierter Größe)."
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
-"Zammad entfernt die E-Mails trotzdem aus dem Postfach (falls aktiviert)."
+"Dennoch wird Zammad die Mails aus dem Postfach entfernen (falls aktiviert)."
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr "Option ist auf ``nein`` gestellt"
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -2412,16 +2471,16 @@ msgstr ""
 "bekommen **keine Benachrichtigung**, dass E-Mails zu groß sind. Zammad wird "
 "die Administratoren jedoch über die Monitoring-Funktion benachrichtigen."
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr "Erfahren Sie mehr über :doc:`/system/monitoring`."
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 "Absender basierend auf Reply-To-Header: Standardwert ``nicht gesetzt (-)``"
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
@@ -2432,12 +2491,12 @@ msgstr ""
 "kann z.B. nützlich sein, wenn Sie mit einem Formular arbeiten, das ``Reply-"
 "To`` Header übergibt."
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 "Option gesetzt auf ``Nutze \"Reply-To\"-Feld als Absender einer E-Mail.``"
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
@@ -2445,7 +2504,7 @@ msgstr ""
 "Diese Einstellung überschreibt den ``Von``-Wert mit dem , der in ``Reply-"
 "To`` steht."
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
@@ -2453,7 +2512,7 @@ msgstr ""
 "Option gesetzt auf ``-`` oder ``Nutze \"Reply-To\"-Feld als Absender einer E-"
 "Mail, aber den angezeigten Namen des \"From\"-Feldes.``"
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
@@ -2463,20 +2522,20 @@ msgstr ""
 "Mail-Adresse des ``Reply-To``-Feldes in Kombination mit den Namen aus dem "
 "``Von``-Feld verwendet."
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 "Kundenauswahl basierend auf Sender- und Empfängerliste. Standardwert: ``ja``"
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 "Diese Einstellung legt fest, wie mit E-Mails umgegangen wird, die von "
 "Agenten an Zammad geschickt werden."
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
@@ -2484,11 +2543,11 @@ msgstr ""
 "Wenn der Sender ein Agent ist, wird der erste Benutzer in der Empfängerliste "
 "als Kunde eingestellt."
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr "Der Agent wird als Kunde gesetzt."
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
@@ -2499,11 +2558,11 @@ msgstr ""
 "dann Ihr Ticket (als Kunde) sehen, auch wenn Sie keine Berechtigung für die "
 "Gruppe haben."
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr "Benachrichtigungen stoppen"
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
@@ -2513,7 +2572,7 @@ msgstr ""
 "Benachrichtigungen geschickt werden. Standardmäßig sind hier bereits "
 "typische Adressen angelegt, die sowieso keine E-Mails empfangen können."
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
@@ -2521,7 +2580,7 @@ msgstr ""
 "Standardwert ist: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply.+?|"
 "no-reply|no-reply.+?)@.+?``"
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
@@ -2529,7 +2588,7 @@ msgstr ""
 "Absender-Format. Standardwert: ``Name des Agenten + Von-Trenner + "
 "Anzeigename der Systemadresse``"
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
@@ -2537,7 +2596,7 @@ msgstr ""
 "Diese Einstellung definiert den Anzeigename, der im ``Von``-Header von "
 "Zammad in ausgehenden E-Mails verwendet wird."
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
@@ -2548,14 +2607,14 @@ msgstr ""
 "werden (z.B. Trigger-basierte Benachrichtigungen), verwenden immer den "
 "``Anzeigename System-Adresse``."
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 "Einstellung auf ``Name des Agenten + Von-Trenner + Anzeigename der "
 "Systemadresse`` gesetzt"
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
@@ -2563,15 +2622,15 @@ msgstr ""
 "Zammad setzt damit den Namen des Agenten und den System-Namen in den ``Von`` "
 "Header, getrennt durch ein Trennzeichen (siehe folgende Konfiguration)."
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr "Beispiel: ``Christopher Miller via Chrispresso Inc.``."
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr "Einstellung auf ``Anzeigename der Systemadresse``"
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
@@ -2579,19 +2638,19 @@ msgstr ""
 "Dadurch wird Zammad immer den Namen des E-Mail-Kanals der jeweiligen Gruppe "
 "in den ``Von`` Header eintragen."
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr "Beispiel: ``Chrispresso Inc.``"
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr "Einstellung auf ``Agenten-Name`` gesetzt"
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr "Zammad verwendet dadurch den Agentenname, was persönlicher ist."
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
@@ -2599,11 +2658,11 @@ msgstr ""
 "Wenn Sie die Ticket-Referenz aus dem Betreff entfernen möchten, können Sie "
 "in :doc:`Einstellungen > Ticket </settings/ticket>` mehr erfahren."
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr "Sender Format Trenner. Standardwert: ``via``"
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
@@ -2611,11 +2670,11 @@ msgstr ""
 "Das kann ein Text Ihrer Wahl sein. Dieser trennt den Namen des Agenten und "
 "den Anzeigenamen des Kanals einer Gruppe."
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr "Ticket Betreff bei Weiterleitung. Standardwert: ``FWD``"
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
@@ -2623,15 +2682,15 @@ msgstr ""
 "Die oben genannte Zeichenkette wird beim Weiterleiten einer E-Mail aus "
 "Zammad verwendet."
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr "``:`` wird der Zeichenkette automatisch angehängt."
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr "Ticket Betreff bei Antwort. Standardwert: ``RE``"
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
@@ -2639,11 +2698,11 @@ msgstr ""
 "Die oben genannte Zeichenkette wird beim Beantworten einer E-Mail aus Zammad "
 "verwendet."
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr "Ticket Betreff Größe. Standardwert: ``110``"
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2654,7 +2713,7 @@ msgstr ""
 "Antworten. Falls der Betreff zu lang ist, wird Zammad diesen automatisch "
 "abschneiden und ``[...]`` einfügen, um die Kürzung anzuzeigen."
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
@@ -2662,15 +2721,15 @@ msgstr ""
 "Das betrifft *nicht* den angezeigten Titel des Tickets in Zammad, sondern "
 "nur den Betreff in E-Mails."
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr "Beispiel: ``RE: Test irgendw[...] [Ticket#123456]``"
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr "Erweiterte Einstellungen"
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "
@@ -18592,25 +18651,31 @@ msgstr ""
 
 #: ../settings/security/third-party.rst:100
 msgid "No User Creation on Logon"
-msgstr ""
+msgstr "Keine Erstellung von Benutzern bei der Anmeldung"
 
 #: ../settings/security/third-party.rst:102
 msgid ""
 "By default, Zammad will create a new user account if the user logs in via a "
 "third-party application and the account doesn't exist yet."
 msgstr ""
+"Standardmäßig erstellt Zammad ein neues Benutzerkonto, wenn sich der "
+"Benutzer über eine Drittanbieteranwendung anmeldet und das Konto noch nicht "
+"existiert."
 
 #: ../settings/security/third-party.rst:105
 msgid ""
 "If you want to prevent Zammad from creating new accounts on logon, you can "
 "disable this feature by setting ``No user creation on logon`` to ``yes``."
 msgstr ""
+"Wenn Sie verhindern wollen, dass Zammad bei der Anmeldung neue Konten "
+"anlegt, können Sie diese Funktion deaktivieren, indem Sie ``Keine Erstellung "
+"von Benutzern bei der Anmeldung`` auf ``ja`` setzen."
 
 #: ../settings/security/third-party.rst:None
-#, fuzzy
-#| msgid "Screenshot showing the location of the Remove action"
 msgid "Screenshot showing the \"no user creation on logon\" setting"
-msgstr "Screenshot, der die Aktion \"Entfernen\" zeigt"
+msgstr ""
+"Screenshot zeigt die Einstellung \"keine Erstellung von Benutzern bei der "
+"Anmeldung\""
 
 #: ../settings/security/third-party/facebook.rst:4
 msgid ""
@@ -32302,6 +32367,25 @@ msgstr "Version"
 msgid "Shows which version is currently being used on your Zammad-instance."
 msgstr ""
 "Zeigt an, welche Version derzeit auf Ihrer Zammad-Instanz verwendet wird."
+
+#~ msgid ""
+#~ "In some situations the normal follow-up detection is not enough. This "
+#~ "might be due to missing references in the subject (the ticket hook and "
+#~ "number). These options can help to recognize follow-ups to existing "
+#~ "tickets."
+#~ msgstr ""
+#~ "In manchen Szenarien ist die normale Nachfrage-Erkennung nicht "
+#~ "ausreichend. Das kann beispielsweise sein, wenn im Betreff die Ticket-"
+#~ "Referenz (Ticket-Hook und Nummer) fehlt. Das Einschalten dieser Option "
+#~ "hilft, auch in solchen Fällen eine Zuordnung von E-Mails zu bestehenden "
+#~ "Tickets zu bekommen."
+
+#~ msgid ""
+#~ "Please note that searching in attachment and body might lead to *false "
+#~ "follow-up detection*."
+#~ msgstr ""
+#~ "Bitte beachten Sie, dass die Suche im Anhang und im Text zu einer "
+#~ "*falschen Erkennung von Nachfragen* führen kann."
 
 #~ msgid ""
 #~ "Chat is becoming more and more important in the customer support. If used "

--- a/locale/es/LC_MESSAGES/admin-docs.po
+++ b/locale/es/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: 2024-06-02 23:00+0000\n"
 "Last-Translator: Jordi Ferri <ferri1989@gmail.com>\n"
 "Language-Team: Spanish <https://translations.zammad.org/projects/"
@@ -2024,58 +2024,106 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+#, fuzzy
+#| msgid "Bad experiences"
+msgid "References"
+msgstr "Malas experiencias"
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -2083,189 +2131,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2273,21 +2321,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "
@@ -26388,9 +26436,6 @@ msgstr ""
 
 #~ msgid "Solving my problem quickly"
 #~ msgstr "Resolver mi problema de manera rápida"
-
-#~ msgid "Bad experiences"
-#~ msgstr "Malas experiencias"
 
 #~ msgid ""
 #~ "A chat window on a website (while the chat being offline) with the hint "

--- a/locale/es_CO/LC_MESSAGES/admin-docs.po
+++ b/locale/es_CO/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1916,58 +1916,104 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+msgid "References"
+msgstr ""
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -1975,189 +2021,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2165,21 +2211,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "

--- a/locale/es_MX/LC_MESSAGES/admin-docs.po
+++ b/locale/es_MX/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: 2023-10-11 14:18+0000\n"
 "Last-Translator: morealedgar <morealedgar@gmail.com>\n"
 "Language-Team: Spanish (Mexico) <https://translations.zammad.org/projects/"
@@ -1919,58 +1919,106 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+#, fuzzy
+#| msgid "Bad experiences"
+msgid "References"
+msgstr "Malas experiencias"
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -1978,189 +2026,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2168,21 +2216,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "
@@ -26097,9 +26145,6 @@ msgstr ""
 
 #~ msgid "Solving my problem quickly"
 #~ msgstr "Resolviendo mi problema rápido"
-
-#~ msgid "Bad experiences"
-#~ msgstr "Malas experiencias"
 
 #, fuzzy
 #~| msgid "Our answer: The Zammad Chat Widget"

--- a/locale/fa/LC_MESSAGES/admin-docs.po
+++ b/locale/fa/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1916,58 +1916,104 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+msgid "References"
+msgstr ""
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -1975,189 +2021,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2165,21 +2211,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "

--- a/locale/fr/LC_MESSAGES/admin-docs.po
+++ b/locale/fr/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: 2024-07-09 00:00+0000\n"
 "Last-Translator: Guy S <guy@bilog.fr>\n"
 "Language-Team: French <https://translations.zammad.org/projects/"
@@ -2073,58 +2073,106 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+#, fuzzy
+#| msgid "Bad experiences"
+msgid "References"
+msgstr "Mauvaises expériences"
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -2132,189 +2180,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2322,22 +2370,22 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 #, fuzzy
 msgid "Enhanced Settings"
 msgstr "Paramètres"
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "
@@ -26479,9 +26527,6 @@ msgstr ""
 
 #~ msgid "Solving my problem quickly"
 #~ msgstr "Résoudre mon problème rapidement"
-
-#~ msgid "Bad experiences"
-#~ msgstr "Mauvaises expériences"
 
 #~ msgid ""
 #~ "A chat window on a website (while the chat being offline) with the hint "

--- a/locale/fr_CA/LC_MESSAGES/admin-docs.po
+++ b/locale/fr_CA/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: 2021-12-03 14:33+0000\n"
 "Last-Translator: TRANSFER FROM TRANSIFEX <support@zammad.com>\n"
 "Language-Team: French (Canada) <https://translations.zammad.org/projects/"
@@ -2026,50 +2026,90 @@ msgstr ""
 "Cette adresse est pertinente pour les notifications d'agent et les courriels "
 "de réinitialisation de mot de passe (affecte également les clients)."
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+#, fuzzy
+#| msgid "Additional follow-up detection"
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr "Détection supplémentaire de suivi"
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
 msgstr ""
-"Dans certaines situations, la détection normale de suivi n'est pas "
-"suffisante. Ceci peut être dû à des références manquantes dans le "
-"\"Sujet\" (le crochet et le numéro du billet). Ces options peuvent aider à "
-"reconnaître les suivis des billets existants."
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
+msgstr ""
 
 #: ../channels/email/settings.rst:31
-#, fuzzy
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
-"Veuillez noter que la recherche dans les pièces jointes et le corps du "
-"message peut entraîner de fausses détections de suivi."
 
 #: ../channels/email/settings.rst:37
+msgid "References"
+msgstr ""
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr "Taille maximale d'un courriel: valeur par défaut ``10 MB``"
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr "Option réglée sur ``yes``"
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
@@ -2080,15 +2120,16 @@ msgstr ""
 "style maître de poste. Ceci aidera votre utilisateur à comprendre que son "
 "courriel n'est pas arrivé et ne sera pas examiné par un agent."
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr "Option réglée sur ``no``"
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -2101,30 +2142,30 @@ msgstr ""
 "de surveillance pour alerter ses administrateurs qu'il ne peut pas récupérer "
 "un courriel trop volumineux."
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr "En savoir plus sur :doc:`/system/monitoring`."
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 "Expéditeur basé sur l'en-tête \"Répondre à\": valeur par défaut ``not set "
 "(-)``"
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 #, fuzzy
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 "Option définie sur ``-`` ou ``Take reply-to header as sender/from of email``"
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
@@ -2132,7 +2173,7 @@ msgstr ""
 "Ce réglage remplacera complètement le ``De`` initial par la valeur utilisée "
 "dans ``Répondre à``."
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 #, fuzzy
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
@@ -2141,7 +2182,7 @@ msgstr ""
 "Option définie sur ``Prendre l'en-tête \"Répondre à\" comme expéditeur "
 "\"De\" du courriel et utiliser le véritable nom \"De\"``"
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
@@ -2151,7 +2192,7 @@ msgstr ""
 "courriel de l'en-tête ``Répondre à`` et utilise le nom de l'en-tête ``DE``, "
 "s'il est donné."
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 #, fuzzy
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
@@ -2159,22 +2200,22 @@ msgstr ""
 "Sélection du client en fonction de l'expéditeur et de la liste de réception: "
 "valeur par défaut ``yes``"
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr "L'agent sera défini comme client du billet."
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 #, fuzzy
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
@@ -2186,18 +2227,18 @@ msgstr ""
 "ne peuvent pas voir leurs propres billets (en tant que client) s'ils n'ont "
 "pas accès au groupe."
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr "Bloquer les notifications"
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
@@ -2205,7 +2246,7 @@ msgstr ""
 "La valeur par défaut est ``(mailer-daemon | postmaster | abuse | root | "
 "noreply | noreply.+? | no-reply | no-reply.+?)@.+?``"
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 #, fuzzy
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
@@ -2214,7 +2255,7 @@ msgstr ""
 "Format de l'expéditeur: valeur par défaut ``Agent + séparateur de format + "
 "nom d'affichage de l'adresse système``"
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
@@ -2222,34 +2263,34 @@ msgstr ""
 "Ceci configure le nom d'affichage utilisé dans l'en-tête ``De`` des "
 "courriels envoyés par Zammad."
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 #, fuzzy
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr "Option définie sur ``Nom d'affichage de l'adresse système``"
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr "Exemple: ``Christopher Miller via Chrispresso Inc.``."
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr "Option définie sur ``Nom d'affichage de l'adresse système``"
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
@@ -2257,54 +2298,54 @@ msgstr ""
 "Ceci obligera Zammad à toujours utiliser le nom d'affichage du canal utilisé "
 "dans l'en-tête ``De``."
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr "Exemple: ``Chrispresso Inc.``"
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 #, fuzzy
 msgid "Sender Format Separator: Default value ``via``"
 msgstr "Sender Format Separator: valeur par défaut ``via``"
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr "\"Sujet\" d'un billet transféré: valeur par défaut ``FWD``"
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr "``:`` sera automatiquement ajouté à la chaîne ci-dessus."
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr "\"Répondre à\" du \"Sujet\" du billet: valeur par défaut ``RE``"
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
@@ -2312,11 +2353,11 @@ msgstr ""
 "La chaîne ci-dessus sera utilisée pour le \"Sujet\" si vous répondez à un "
 "courriel de Zammad."
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr "Taille du \"Sujet\" du billet: valeur par défaut ``110``"
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2328,23 +2369,23 @@ msgstr ""
 "tronquera automatiquement la longueur et insérera ``[...]`` pour montrer "
 "qu'il a raccourci le sujet."
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr "Exemple: ``RE: Testez un peu [...] [Billet #: 123456] ``"
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 #, fuzzy
 #| msgid "Enhanced settings"
 msgid "Enhanced Settings"
 msgstr "Réglages avancés"
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "
@@ -26570,6 +26611,25 @@ msgstr ""
 #: ../system/version.rst:4
 msgid "Shows which version is currently being used on your Zammad-instance."
 msgstr ""
+
+#~ msgid ""
+#~ "In some situations the normal follow-up detection is not enough. This "
+#~ "might be due to missing references in the subject (the ticket hook and "
+#~ "number). These options can help to recognize follow-ups to existing "
+#~ "tickets."
+#~ msgstr ""
+#~ "Dans certaines situations, la détection normale de suivi n'est pas "
+#~ "suffisante. Ceci peut être dû à des références manquantes dans le "
+#~ "\"Sujet\" (le crochet et le numéro du billet). Ces options peuvent aider "
+#~ "à reconnaître les suivis des billets existants."
+
+#, fuzzy
+#~ msgid ""
+#~ "Please note that searching in attachment and body might lead to *false "
+#~ "follow-up detection*."
+#~ msgstr ""
+#~ "Veuillez noter que la recherche dans les pièces jointes et le corps du "
+#~ "message peut entraîner de fausses détections de suivi."
 
 #, fuzzy
 #~ msgid ""

--- a/locale/hr/LC_MESSAGES/admin-docs.po
+++ b/locale/hr/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: 2022-06-15 13:40+0000\n"
 "Last-Translator: Ivan Perovic <ip@zammad.com>\n"
 "Language-Team: Croatian <https://translations.zammad.org/projects/"
@@ -1984,58 +1984,106 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+#, fuzzy
+#| msgid "Bad experiences"
+msgid "References"
+msgstr "Loša iskustva"
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -2043,189 +2091,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2233,21 +2281,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "
@@ -26238,9 +26286,6 @@ msgstr ""
 
 #~ msgid "Solving my problem quickly"
 #~ msgstr "Brzo rješavanje problema"
-
-#~ msgid "Bad experiences"
-#~ msgstr "Loša iskustva"
 
 #~ msgid ""
 #~ "A chat window on a website (while the chat being offline) with the hint "

--- a/locale/hu/LC_MESSAGES/admin-docs.po
+++ b/locale/hu/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1916,58 +1916,104 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+msgid "References"
+msgstr ""
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -1975,189 +2021,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2165,21 +2211,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "

--- a/locale/it/LC_MESSAGES/admin-docs.po
+++ b/locale/it/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: 2023-04-15 10:17+0000\n"
 "Last-Translator: crnfpp <crnfpp@unife.it>\n"
 "Language-Team: Italian <https://translations.zammad.org/projects/"
@@ -1925,58 +1925,106 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+#, fuzzy
+#| msgid "Bad experiences"
+msgid "References"
+msgstr "Brutte esperienze"
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -1984,189 +2032,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2174,21 +2222,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "
@@ -26138,9 +26186,6 @@ msgstr ""
 
 #~ msgid "Solving my problem quickly"
 #~ msgstr "Risolvere rapidamente il mio problema"
-
-#~ msgid "Bad experiences"
-#~ msgstr "Brutte esperienze"
 
 #~ msgid ""
 #~ "A chat window on a website (while the chat being offline) with the hint "

--- a/locale/nl/LC_MESSAGES/admin-docs.po
+++ b/locale/nl/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1916,58 +1916,104 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+msgid "References"
+msgstr ""
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -1975,189 +2021,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2165,21 +2211,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "

--- a/locale/pl/LC_MESSAGES/admin-docs.po
+++ b/locale/pl/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: 2024-06-20 06:00+0000\n"
 "Last-Translator: MBekspert <michal.bosak@ekspert.biz>\n"
 "Language-Team: Polish <https://translations.zammad.org/projects/"
@@ -1921,58 +1921,104 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+msgid "References"
+msgstr ""
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -1980,189 +2026,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2170,21 +2216,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "

--- a/locale/pt_BR/LC_MESSAGES/admin-docs.po
+++ b/locale/pt_BR/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: 2024-03-10 08:00+0000\n"
 "Last-Translator: Glauber Daniel Ribeiro <glauberdribeiro@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://translations.zammad.org/projects/"
@@ -1997,58 +1997,106 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+#, fuzzy
+#| msgid "Bad experiences"
+msgid "References"
+msgstr "Experiências ruins"
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -2056,189 +2104,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2246,22 +2294,22 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 #, fuzzy
 msgid "Enhanced Settings"
 msgstr "Configurações"
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "
@@ -26635,9 +26683,6 @@ msgstr ""
 
 #~ msgid "Solving my problem quickly"
 #~ msgstr "Resolvendo meu problema rapidamente"
-
-#~ msgid "Bad experiences"
-#~ msgstr "Experiências ruins"
 
 #~ msgid ""
 #~ "A chat window on a website (while the chat being offline) with the hint "

--- a/locale/ru/LC_MESSAGES/admin-docs.po
+++ b/locale/ru/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: 2024-08-06 03:16+0000\n"
 "Last-Translator: Nikita <nyakovlev@iko.tech>\n"
 "Language-Team: Russian <https://translations.zammad.org/projects/"
@@ -1950,58 +1950,106 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+#, fuzzy
+#| msgid "Bad experiences"
+msgid "References"
+msgstr "Плохой опыт"
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -2009,189 +2057,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2199,21 +2247,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "
@@ -26161,9 +26209,6 @@ msgstr ""
 
 #~ msgid "Solving my problem quickly"
 #~ msgstr "Быстрое решение моей проблемы"
-
-#~ msgid "Bad experiences"
-#~ msgstr "Плохой опыт"
 
 #~ msgid ""
 #~ "A chat window on a website (while the chat being offline) with the hint "

--- a/locale/sr/LC_MESSAGES/admin-docs.po
+++ b/locale/sr/LC_MESSAGES/admin-docs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad Admin Documentation pre-release\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
-"PO-Revision-Date: 2024-08-22 07:00+0000\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
+"PO-Revision-Date: 2024-08-24 03:16+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
 "documentations/admin-documentation-pre-release/sr/>\n"
@@ -2268,33 +2268,79 @@ msgstr ""
 "Ова адреса је релевантна за обавештења оператера и поруке за ресетовање "
 "лозинке (такође утиче на клијенте)."
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+#, fuzzy
+#| msgid "Additional follow-up detection"
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr "Додатна детекција наставака"
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
 msgstr ""
-"У неким ситуацијама подразумевана детекција наставака није довољна. Ово може "
-"бити због недостајућих референци у теми (прикључак и број тикета). Ове "
-"опције могу помоћи у препознавању наставака постојећих тикета."
+
+#: ../channels/email/settings.rst:33
+#, fuzzy
+#| msgid "Fetch Preferences"
+msgid "Subject & References"
+msgstr "Подешавања преузимања"
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
-"Имајте на уму да претраживање по прилозима и телу поруке може довести до "
-"*лажног откривања наставка*."
 
 #: ../channels/email/settings.rst:37
+#, fuzzy
+#| msgid "API Reference"
+msgid "References"
+msgstr "API референца"
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr "Максимална величина имејл поруке: подразумевана вредност ``10 MB``"
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
@@ -2304,17 +2350,17 @@ msgstr ""
 "поруке коју ће Zammad преузети. Zammad неће преузимати поруке које су веће "
 "од ове вредности (*укључујући и прилоге!*)."
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 "Пошаљите postmaster поруку ако је порука превелика: подразумевана вредност "
 "„да (укључено)“"
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr "Опција је подешена на ``да``"
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
@@ -2325,16 +2371,20 @@ msgstr ""
 "Ово ће помоћи вашем кориснику да схвати да његова пошта није стигла и да је "
 "нећете видети."
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+#, fuzzy
+#| msgid ""
+#| "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 "У сваком случају, Zammad ће уклонити пошту из сандучета (ако је подешено)."
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr "Опција је подешена на ``не``"
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -2346,17 +2396,17 @@ msgstr ""
 "тога, Zammad ће користити путању мониторинга да упозори своје администраторе "
 "да не може да преузме превелику пошту."
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr "Сазнајте више у :doc:`/system/monitoring`."
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 "Пошиљалац на основу Reply-To заглавља: подразумевана вредност ``није "
 "подешено (-)``"
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
@@ -2366,13 +2416,13 @@ msgstr ""
 "порука који садрже ``Reply-To`` заглавље. Ово је корисно ако радите са "
 "контакт формама које морају да користе ово заглавље."
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 "Опција је подешена на ``Преузми Reply-To заглавље као од/за поље имејл "
 "поруке.``"
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
@@ -2380,7 +2430,7 @@ msgstr ""
 "Ово подешавање ће потпуно преписати почетно ``From`` са вредношћу која се "
 "користи у ``Reply-To``."
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
@@ -2388,7 +2438,7 @@ msgstr ""
 "Опција је подешена на ``-`` или ``Преузми Reply-To заглавље као од/за поље "
 "имејл поруке и користи право име изворног пошиљаоца.``"
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
@@ -2398,21 +2448,21 @@ msgstr ""
 "поште из ``Reply-To`` заглавља и користи дати назив из ``From`` заглавља, "
 "ако је дат."
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 "Избор клијента на основу листе пошиљаоца и примаоца: подразумевана вредност "
 "``да``"
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 "Ова опција одлучује како Zammad треба да реагује ако му оператер пошаље "
 "имејл поруку."
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
@@ -2420,11 +2470,11 @@ msgstr ""
 "Први корисник / имејл адреса у листи прималаца ће се користити као клијент "
 "тикета."
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr "Оператер ће бити постављен као клијент тикета."
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
@@ -2434,11 +2484,11 @@ msgstr ""
 "комуникација путем имејла функционише, оператери не могу да виде своје "
 "тикете (као клијенти) уколико немају приступ групи тикета."
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr "Блокирај обавештења"
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
@@ -2449,7 +2499,7 @@ msgstr ""
 "утиче на типичне системске адресе које ионако не могу да примају имејл "
 "поруке."
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
@@ -2457,7 +2507,7 @@ msgstr ""
 "Подразумевана вредност је: ``(mailer-daemon|postmaster|abuse|root|noreply|"
 "noreply.+?|no-reply|no-reply.+?)@.+?``"
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
@@ -2465,7 +2515,7 @@ msgstr ""
 "Формат пошиљаоца: подразумевана вредност ``Назив оператера + сепаратор + "
 "назив системске адресе``"
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
@@ -2473,7 +2523,7 @@ msgstr ""
 "Ово одређује назив за приказ који се користи у ``From`` заглављу порука које "
 "Zammad шаље."
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
@@ -2484,13 +2534,13 @@ msgstr ""
 "заснована на окидачу) увек ће се по потреби вратити на ``Назив системске "
 "адресе``."
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 "Опција подешена на ``Назив оператера + сепаратор + назив системске адресе``"
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
@@ -2498,15 +2548,15 @@ msgstr ""
 "Ово ће резултовати да Zammad постави ``From`` заглавље на име оператера и "
 "назив канала, подељено сепаратором (подешено испод)."
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr "Пример: ``Christopher Miller via Chrispresso Inc.``."
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr "Опција је подешена на ``Назив системске адресе``"
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
@@ -2514,19 +2564,19 @@ msgstr ""
 "Ово ће резултовати да Zammad увек користи назив коришћеног канала у ``From`` "
 "заглављу."
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr "Пример: ``Chrispresso Inc.``"
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr "Опција постављена на ``Назив оператера``"
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr "Zammad ће користити име оператера које је обично лично."
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
@@ -2534,11 +2584,11 @@ msgstr ""
 "За уклањање референце тикета из предмета, сазнајте више у одељку :doc:"
 "`Подешавања > Тикет </settings/ticket>`."
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr "Сепаратор формата пошиљаоца: подразумевана вредност ``via``"
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
@@ -2546,11 +2596,11 @@ msgstr ""
 "Ово може бити текст слободног избора. Он дели име оператера и назив канала "
 "кад год је то потребно."
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr "Предмет прослеђених тикета: подразумевана вредност ``FWD``"
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
@@ -2558,15 +2608,15 @@ msgstr ""
 "Горњи текст ће се користити за предмет ако проследите имејл поруку из Zammad-"
 "а."
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr "``:`` ће аутоматски бити додато на горњи текст."
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr "Предмет одговора тикета: подразумевана вредност ``RE``"
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
@@ -2574,11 +2624,11 @@ msgstr ""
 "Горњи текст ће се користити за предмет ако одговорите имејл поруку у Zammad-"
 "у."
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr "Дужина предмета тикета: подразумевана вредност ``110``"
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2590,7 +2640,7 @@ msgstr ""
 "скратити дужину и уметнути ``[...]`` да би сигнализирао да је скратио "
 "предмет."
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
@@ -2598,15 +2648,15 @@ msgstr ""
 "Ово *не* ограничава наслове тикета унутар корисничког интерфејса, већ само "
 "предмете приликом одговора на имејл поруке."
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr "Пример: ``RE: Test somew[…] [Ticket#123456]``"
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr "Напредна подешавања"
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "
@@ -18043,25 +18093,29 @@ msgstr ""
 
 #: ../settings/security/third-party.rst:100
 msgid "No User Creation on Logon"
-msgstr ""
+msgstr "Без отварања налога по пријави"
 
 #: ../settings/security/third-party.rst:102
 msgid ""
 "By default, Zammad will create a new user account if the user logs in via a "
 "third-party application and the account doesn't exist yet."
 msgstr ""
+"Подразумевано, Zammad ће отворити нови кориснички налог ако се корисник "
+"пријављује преко апликације трећег лица и налог још увек не постоји."
 
 #: ../settings/security/third-party.rst:105
 msgid ""
 "If you want to prevent Zammad from creating new accounts on logon, you can "
 "disable this feature by setting ``No user creation on logon`` to ``yes``."
 msgstr ""
+"Уколико желите да спречите Zammad да отвара нове налоге по пријави, можете "
+"искључити ову функцију постављањем ``Без отварања налога по пријави``на "
+"``да``."
 
 #: ../settings/security/third-party.rst:None
-#, fuzzy
-#| msgid "Screenshot showing the location of the Remove action"
 msgid "Screenshot showing the \"no user creation on logon\" setting"
-msgstr "Снимак екрана који приказује позицију радње Уклони"
+msgstr ""
+"Снимак екрана који приказује подешавање „Без отварања налога по пријави”"
 
 #: ../settings/security/third-party/facebook.rst:4
 msgid ""
@@ -31362,6 +31416,23 @@ msgstr "Верзија"
 #: ../system/version.rst:4
 msgid "Shows which version is currently being used on your Zammad-instance."
 msgstr "Приказује која верзија се користи тренутно на вашој Zammad инстанци."
+
+#~ msgid ""
+#~ "In some situations the normal follow-up detection is not enough. This "
+#~ "might be due to missing references in the subject (the ticket hook and "
+#~ "number). These options can help to recognize follow-ups to existing "
+#~ "tickets."
+#~ msgstr ""
+#~ "У неким ситуацијама подразумевана детекција наставака није довољна. Ово "
+#~ "може бити због недостајућих референци у теми (прикључак и број тикета). "
+#~ "Ове опције могу помоћи у препознавању наставака постојећих тикета."
+
+#~ msgid ""
+#~ "Please note that searching in attachment and body might lead to *false "
+#~ "follow-up detection*."
+#~ msgstr ""
+#~ "Имајте на уму да претраживање по прилозима и телу поруке може довести до "
+#~ "*лажног откривања наставка*."
 
 #~ msgid ""
 #~ "Chat is becoming more and more important in the customer support. If used "

--- a/locale/sv/LC_MESSAGES/admin-docs.po
+++ b/locale/sv/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: 2024-02-01 11:00+0000\n"
 "Last-Translator: kjellbrandes <kjell@zippit.se>\n"
 "Language-Team: Swedish <https://translations.zammad.org/projects/"
@@ -1920,58 +1920,106 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+#, fuzzy
+#| msgid "Good experiences"
+msgid "References"
+msgstr "Bra erfarenheter"
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -1979,189 +2027,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2169,21 +2217,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "
@@ -26081,6 +26129,3 @@ msgstr ""
 #: ../system/version.rst:4
 msgid "Shows which version is currently being used on your Zammad-instance."
 msgstr ""
-
-#~ msgid "Good experiences"
-#~ msgstr "Bra erfarenheter"

--- a/locale/th/LC_MESSAGES/admin-docs.po
+++ b/locale/th/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1916,58 +1916,104 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+msgid "References"
+msgstr ""
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -1975,189 +2021,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2165,21 +2211,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "

--- a/locale/tr/LC_MESSAGES/admin-docs.po
+++ b/locale/tr/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: 2024-05-22 09:00+0000\n"
 "Last-Translator: Berkay Gökmen <berkaygokmen24@gmail.com>\n"
 "Language-Team: Turkish <https://translations.zammad.org/projects/"
@@ -2047,58 +2047,108 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
 msgstr ""
+
+#: ../channels/email/settings.rst:33
+#, fuzzy
+#| msgid "Fetch Preferences"
+msgid "Subject & References"
+msgstr "Getirme Tercihleri"
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+#, fuzzy
+#| msgid "API Reference"
+msgid "References"
+msgstr "API Referansı"
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr "Maksimum E-posta Boyutu: Varsayılan değer ``10 MB``"
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -2106,83 +2156,83 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ":doc:`/system/monitoring` hakkınd daha fazla bilgi al."
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr "Bildirimleri Engelle"
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
@@ -2190,107 +2240,107 @@ msgstr ""
 "Öntanımlı değer: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply.+?|"
 "no-reply|no-reply.+?)@.+?``"
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr "Örnek: ``Christopher Miller via Chrispresso Inc.``."
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr "Örnek: ``Chrispresso Inc.``"
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr "Bilet Konusu Yanıtı: Varsayılan değer ``YNT``"
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr "Bilet Konusu Boyutu: Varsayılan değer ``110``"
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2298,23 +2348,23 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr "Örnek: ``YNT: Test konu[...] [Bilet#123456]``"
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 #, fuzzy
 #| msgid "Enhanced settings"
 msgid "Enhanced Settings"
 msgstr "Gelişmiş ayarlar"
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "

--- a/locale/zh_Hans/LC_MESSAGES/admin-docs.po
+++ b/locale/zh_Hans/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-22 10:56+0100\n"
+"POT-Creation-Date: 2024-08-23 13:17+0200\n"
 "PO-Revision-Date: 2023-08-14 12:18+0000\n"
 "Last-Translator: chen <chenchen@4chian.com>\n"
 "Language-Team: Chinese (Simplified) <https://translations.zammad.org/"
@@ -1991,58 +1991,106 @@ msgid ""
 "(also affects customers)."
 msgstr ""
 
-#: ../channels/email/settings.rst:32
-msgid "Additional follow-up detection"
+#: ../channels/email/settings.rst:53
+msgid "Additional follow-up detection: Default value ``Subject & References``"
 msgstr ""
 
 #: ../channels/email/settings.rst:26
 msgid ""
-"In some situations the normal follow-up detection is not enough. This might "
-"be due to missing references in the subject (the ticket hook and number). "
-"These options can help to recognize follow-ups to existing tickets."
+"Adjust how Zammad checks if an incoming email is a follow-up or not. If you "
+"disable all checks, Zammad only checks if a matching ticket hook & number is "
+"present in the subject."
+msgstr ""
+
+#: ../channels/email/settings.rst:33
+msgid "Subject & References"
 msgstr ""
 
 #: ../channels/email/settings.rst:31
 msgid ""
-"Please note that searching in attachment and body might lead to *false "
-"follow-up detection*."
+"Checks subject and message IDs of emails and searches for initial ticket "
+"articles with the same subject and message ID. When both are matching, it is "
+"considered as a follow-up."
 msgstr ""
 
 #: ../channels/email/settings.rst:37
+#, fuzzy
+#| msgid "Bad experiences"
+msgid "References"
+msgstr "糟糕的经历"
+
+#: ../channels/email/settings.rst:36
+msgid ""
+"Additionally checks if a message ID from email matches an existing article."
+msgstr ""
+
+#: ../channels/email/settings.rst:42
+msgid "Attachment"
+msgstr ""
+
+#: ../channels/email/settings.rst:40
+msgid ""
+"Additionally checks attachments of emails. Useful if you often get emails "
+"forwarded as attachments and want to have them in existing tickets, if there "
+"is a reference included in an attached email."
+msgstr ""
+
+#: ../channels/email/settings.rst:49
+msgid "Body"
+msgstr ""
+
+#: ../channels/email/settings.rst:45
+msgid ""
+"Additionally checks the body of emails. If there is a ticket identifier "
+"(ticket hook & number) in the body, it is considered as a follow-up. Useful "
+"if you want to add emails to existing tickets which are completely "
+"independent but talking about existing tickets including such a ticket "
+"reference."
+msgstr ""
+
+#: ../channels/email/settings.rst:51
+msgid ""
+"Please note that activating additional checks can lead to false detection. "
+"In production environments, you should change this setting very carefully "
+"and monitor the behavior afterwards."
+msgstr ""
+
+#: ../channels/email/settings.rst:58
 msgid "Maximum Email Size: Default value ``10 MB``"
 msgstr ""
 
-#: ../channels/email/settings.rst:35
+#: ../channels/email/settings.rst:56
 msgid ""
 "This one is pretty obvious: It defines the maximum allowed size of an email "
 "Zammad will fetch. Zammad will not fetch emails that are bigger than this "
 "option (*including attachments!*)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Send postmaster mail if mail too large: Default value ``yes (enabled)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:47 ../channels/email/settings.rst:76
+#: ../channels/email/settings.rst:68 ../channels/email/settings.rst:97
 msgid "Option set to ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:41
+#: ../channels/email/settings.rst:62
 msgid ""
 "This setting will cause Zammad to automatically reply to mails that exceed "
 "the above mail size limit with a postmaster style mail. This will help your "
 "user to understand that his mail did not arrive and won't be reviewed by you."
 msgstr ""
 
-#: ../channels/email/settings.rst:46
-msgid "Nvertheless, Zammad will remove the mail from the mailbox (if enabled)."
+#: ../channels/email/settings.rst:67
+msgid ""
+"Nevertheless, Zammad will remove the mail from the mailbox (if enabled)."
 msgstr ""
 
-#: ../channels/email/settings.rst:55 ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:76 ../channels/email/settings.rst:100
 msgid "Option set to ``no``"
 msgstr ""
 
-#: ../channels/email/settings.rst:50
+#: ../channels/email/settings.rst:71
 msgid ""
 "If the option is set to no, Zammad will not reply to mails that are too big. "
 "Your customer will **not notice** that the mail was too large! Instead, "
@@ -2050,189 +2098,189 @@ msgid ""
 "can't fetch a too large mail."
 msgstr ""
 
-#: ../channels/email/settings.rst:55
+#: ../channels/email/settings.rst:76
 msgid "Learn more about :doc:`/system/monitoring`."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid "Sender based on Reply-To header: Default value ``not set (-)``"
 msgstr ""
 
-#: ../channels/email/settings.rst:58
+#: ../channels/email/settings.rst:79
 msgid ""
 "This setting decides how Zammad should recognize its customers from emails "
 "that contain a ``Reply-To`` header. This comes in useful if you're working "
 "with contact forms that need to use reply to headers."
 msgstr ""
 
-#: ../channels/email/settings.rst:64
+#: ../channels/email/settings.rst:85
 msgid "Option set to ``Take reply-to header as sender/from of email.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:63
+#: ../channels/email/settings.rst:84
 msgid ""
 "This setting will overwrite the initial ``FROM`` to the value used in "
 "``Reply-To`` completely."
 msgstr ""
 
-#: ../channels/email/settings.rst:69
+#: ../channels/email/settings.rst:90
 msgid ""
 "Option set to ``-`` or ``Take Reply-To header as sender/from of email and "
 "use the real name of origin from.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:67
+#: ../channels/email/settings.rst:88
 msgid ""
 "This setting will partially overwrite the initial ``FROM``. It uses the mail "
 "address from the ``Reply-To`` header and uses the given name of the ``FROM`` "
 "header, if given."
 msgstr ""
 
-#: ../channels/email/settings.rst:85
+#: ../channels/email/settings.rst:106
 msgid ""
 "Customer selection based on sender and receiver list: Default value ``yes``"
 msgstr ""
 
-#: ../channels/email/settings.rst:72
+#: ../channels/email/settings.rst:93
 msgid ""
 "This option decides how Zammad should react if an agent sends a email to it."
 msgstr ""
 
-#: ../channels/email/settings.rst:75
+#: ../channels/email/settings.rst:96
 msgid ""
 "The first user / email address from the recipient list will be used as the "
 "ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:79
+#: ../channels/email/settings.rst:100
 msgid "The agent will be set as ticket customer."
 msgstr ""
 
-#: ../channels/email/settings.rst:83
+#: ../channels/email/settings.rst:104
 msgid ""
 "Currently agents can't be customers within the UI. While email communication "
 "works, agents can't see their own tickets (as a customer) if they don't have "
 "access to the group."
 msgstr ""
 
-#: ../channels/email/settings.rst:95
+#: ../channels/email/settings.rst:116
 msgid "Block Notifications"
 msgstr ""
 
-#: ../channels/email/settings.rst:88
+#: ../channels/email/settings.rst:109
 msgid ""
 "With the regex that can be defined here, you can ensure not to send any "
 "notifications to specific systems. By default this especially affects "
 "typical system addresses which can't receive emails anyway."
 msgstr ""
 
-#: ../channels/email/settings.rst:92
+#: ../channels/email/settings.rst:113
 msgid ""
 "The default value is: ``(mailer-daemon|postmaster|abuse|root|noreply|noreply."
 "+?|no-reply|no-reply.+?)@.+?``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid ""
 "Sender Format: Default value ``Agent Name + FromSeparator + System Address "
 "Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:98
+#: ../channels/email/settings.rst:119
 msgid ""
 "This configures the display name used in the ``FROM`` header of mails Zammad "
 "sends."
 msgstr ""
 
-#: ../channels/email/settings.rst:101
+#: ../channels/email/settings.rst:122
 msgid ""
 "This does not affect notification mails (to agents) and password reset "
 "mails. Emails that are not sent by agents (e.g. trigger-based notifications) "
 "will always fallback to ``System Address Display Name`` if needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid ""
 "Option set to ``Agent Name + FromSeparator + System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:107
+#: ../channels/email/settings.rst:128
 msgid ""
 "This will cause Zammad to set the ``FROM`` header to agent name and the "
 "channel's display name, divided by a separator (configured below)."
 msgstr ""
 
-#: ../channels/email/settings.rst:110
+#: ../channels/email/settings.rst:131
 msgid "Example: ``Christopher Miller via Chrispresso Inc.``."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Option set to ``System Address Display Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:113
+#: ../channels/email/settings.rst:134
 msgid ""
 "This will cause Zammad to always use the display name of the used channel in "
 "the ``FROM`` header."
 msgstr ""
 
-#: ../channels/email/settings.rst:116
+#: ../channels/email/settings.rst:137
 msgid "Example: ``Chrispresso Inc.``"
 msgstr ""
 
-#: ../channels/email/settings.rst:122
+#: ../channels/email/settings.rst:143
 msgid "Option set to ``Agent Name``"
 msgstr ""
 
-#: ../channels/email/settings.rst:119
+#: ../channels/email/settings.rst:140
 msgid "Zammad will use the agent's name which is very personal."
 msgstr ""
 
-#: ../channels/email/settings.rst:121
+#: ../channels/email/settings.rst:142
 msgid ""
 "If you want to remove the ticket reference from the subject, you can learn "
 "more in :doc:`Settings > Ticket </settings/ticket>`."
 msgstr ""
 
-#: ../channels/email/settings.rst:126
+#: ../channels/email/settings.rst:147
 msgid "Sender Format Separator: Default value ``via``"
 msgstr ""
 
-#: ../channels/email/settings.rst:125
+#: ../channels/email/settings.rst:146
 msgid ""
 "This can be a string you can freely choose. It divides the agent's name and "
 "the display name of the channel whenever needed."
 msgstr ""
 
-#: ../channels/email/settings.rst:132
+#: ../channels/email/settings.rst:153
 msgid "Ticket Subject Forward: Default value ``FWD``"
 msgstr ""
 
-#: ../channels/email/settings.rst:129
+#: ../channels/email/settings.rst:150
 msgid ""
 "The above string will be used on the subject if you forward an email from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:132 ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:153 ../channels/email/settings.rst:159
 msgid "``:`` will be automatically appended to the above string."
 msgstr ""
 
-#: ../channels/email/settings.rst:138
+#: ../channels/email/settings.rst:159
 msgid "Ticket Subject Reply: Default value ``RE``"
 msgstr ""
 
-#: ../channels/email/settings.rst:135
+#: ../channels/email/settings.rst:156
 msgid ""
 "The above string will be used on the subject if you reply to a mail from "
 "Zammad."
 msgstr ""
 
-#: ../channels/email/settings.rst:150
+#: ../channels/email/settings.rst:171
 msgid "Ticket Subject Size: Default value ``110``"
 msgstr ""
 
-#: ../channels/email/settings.rst:141
+#: ../channels/email/settings.rst:162
 msgid ""
 "This setting enforces a maximum length for subjects when replying. If the "
 "subject you're using for your reply is too long, Zammad will automatically "
@@ -2240,21 +2288,21 @@ msgid ""
 "subject."
 msgstr ""
 
-#: ../channels/email/settings.rst:146
+#: ../channels/email/settings.rst:167
 msgid ""
 "This does *not* limit ticket titles within the UI, just the subjects when "
 "replying to an email."
 msgstr ""
 
-#: ../channels/email/settings.rst:149
+#: ../channels/email/settings.rst:170
 msgid "Example: ``RE: Test somew[...] [Ticket#123456]``"
 msgstr ""
 
-#: ../channels/email/settings.rst:153
+#: ../channels/email/settings.rst:174
 msgid "Enhanced Settings"
 msgstr ""
 
-#: ../channels/email/settings.rst:155
+#: ../channels/email/settings.rst:176
 msgid ""
 "Some less relevant settings can be changed via rails console if needed. As "
 "an example, Zammad allows you to send all outgoing communication to a BCC "
@@ -26235,9 +26283,6 @@ msgstr "显示当前在您的Zammad实例上使用的版本。"
 
 #~ msgid "Solving my problem quickly"
 #~ msgstr "快速解决我的问题。"
-
-#~ msgid "Bad experiences"
-#~ msgstr "糟糕的经历"
 
 #~ msgid ""
 #~ "A chat window on a website (while the chat being offline) with the hint "


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/Admin Documentation (pre-release)](https://translations.zammad.org/projects/documentations/admin-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/admin-documentation-pre-release/horizontal-auto.svg)