### PR TITLE
Fixes #684 - Pin sphinxcontrib-mermaid dependency to v0.9.2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ sphinxcontrib-devhelp<1.0.6
 sphinxcontrib-htmlhelp<2.0.5
 sphinxcontrib-serializinghtml<1.1.10
 sphinxcontrib-qthelp<1.0.7
-sphinxcontrib-mermaid
+sphinxcontrib-mermaid<=0.9.2
 docutils


### PR DESCRIPTION
@ralf401 Let's wait until the workflow finishes and check the build if it contains the correct graph.