### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/sr/LC_MESSAGES/admin-docs.po
+++ b/locale/sr/LC_MESSAGES/admin-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad Admin Documentation pre-release\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-07 13:55+0100\n"
-"PO-Revision-Date: 2024-11-08 03:00+0000\n"
+"PO-Revision-Date: 2024-11-12 09:01+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
 "documentations/admin-documentation-pre-release/sr/>\n"
@@ -10272,16 +10272,12 @@ msgid "Accessing chat for agents: ``chat.agent``"
 msgstr "Приступ ћаскању за оператере: ``chat.agent``"
 
 #: ../manage/roles/admin-permissions.rst:53
-#, fuzzy
-#| msgid "``admin.security``"
 msgid "``admin.checklist``"
-msgstr "``admin.security``"
+msgstr "``admin.checklist``"
 
 #: ../manage/roles/admin-permissions.rst:54
-#, fuzzy
-#| msgid ":doc:`Manage > Scheduler </manage/scheduler>`"
 msgid ":doc:`Manage > Checklist </manage/checklist>`"
-msgstr ":doc:`Манаге > Планер </manage/scheduler>`"
+msgstr ":doc:`Управљање > Списак задатака </manage/checklist>`"
 
 #: ../manage/roles/admin-permissions.rst:56
 msgid "``admin.channel_email``"
@@ -10374,16 +10370,12 @@ msgid ":doc:`Channels > Web </channels/web>`"
 msgstr ":doc:`Канали > Веб </channels/web>`"
 
 #: ../manage/roles/admin-permissions.rst:83
-#, fuzzy
-#| msgid "``admin.channel_chat``"
 msgid "``admin.channel_whatsapp``"
-msgstr "``admin.channel_chat``"
+msgstr "``admin.channel_whatsapp``"
 
 #: ../manage/roles/admin-permissions.rst:84
-#, fuzzy
-#| msgid ":doc:`Channels > Chat </channels/chat>`"
 msgid ":doc:`Channels > Whatsapp </channels/whatsapp/index>`"
-msgstr ":doc:`Канали > Ћаскање </channels/chat>`"
+msgstr ":doc:`Канали > Whatsapp </channels/whatsapp/index>`"
 
 #: ../manage/roles/admin-permissions.rst:86
 msgid "``admin.core_workflows``"
@@ -10514,16 +10506,12 @@ msgid ":doc:`Manage > Overviews</manage/overviews>`"
 msgstr ":doc:`Управљање > Прегледи </manage/overviews>`"
 
 #: ../manage/roles/admin-permissions.rst:124
-#, fuzzy
-#| msgid "``admin.api``"
 msgid "``admin.public_links``"
-msgstr "``admin.api``"
+msgstr "``admin.public_links``"
 
 #: ../manage/roles/admin-permissions.rst:125
-#, fuzzy
-#| msgid ":doc:`Manage > Calendars </manage/calendars>`"
 msgid ":doc:`Manage > Public Links </manage/public-links>`"
-msgstr ":doc:`Управљање > Календари </manage/calendars>`"
+msgstr ":doc:`Управљање > Јавни линкови </manage/public-links>`"
 
 #: ../manage/roles/admin-permissions.rst:127
 msgid "``admin.package``"
@@ -10559,7 +10547,7 @@ msgstr "``admin.scheduler``"
 
 #: ../manage/roles/admin-permissions.rst:137
 msgid ":doc:`Manage > Scheduler </manage/scheduler>`"
-msgstr ":doc:`Манаге > Планер </manage/scheduler>`"
+msgstr ":doc:`Управљање > Планер </manage/scheduler>`"
 
 #: ../manage/roles/admin-permissions.rst:138
 msgid "For automation on tickets"
@@ -10603,16 +10591,12 @@ msgid ":doc:`Manage > SLAs </manage/slas/index>`"
 msgstr ":doc:`Управљање > SLA </manage/slas/index>`"
 
 #: ../manage/roles/admin-permissions.rst:151
-#, fuzzy
-#| msgid "``admin.template``"
 msgid "``admin.system_report``"
-msgstr "``admin.template``"
+msgstr "``admin.system_report``"
 
 #: ../manage/roles/admin-permissions.rst:152
-#, fuzzy
-#| msgid ":doc:`System > Sessions </system/sessions>`"
 msgid ":doc:`System > System Report </system/system-report>`"
-msgstr ":doc:`Систем > Сесије </system/sessions>`"
+msgstr ":doc:`Систем > Системски извештај </system/system-report>`"
 
 #: ../manage/roles/admin-permissions.rst:154
 msgid "``admin.tag``"
@@ -10651,46 +10635,36 @@ msgid "Does not grant access to :doc:`/misc/composer`"
 msgstr "Не дозвољава приступ :doc:`/misc/composer`"
 
 #: ../manage/roles/admin-permissions.rst:166
-#, fuzzy
-#| msgid "``admin.ticket``"
 msgid "``admin.ticket_auto_assignment``"
-msgstr "``admin.ticket``"
+msgstr "``admin.ticket_auto_assignment``"
 
 #: ../manage/roles/admin-permissions.rst:167
-#, fuzzy
-#| msgid ":ref:`Automatic ticket assignment <auto_assignment>`"
 msgid ":ref:`Settings > Ticket > Auto Assignment <auto_assignment>`"
-msgstr ":ref:`Аутоматска додела тикета <auto_assignment>`"
+msgstr ":ref:`Подешавања > Тикет > Аутоматска додела тикета <auto_assignment>`"
 
 #: ../manage/roles/admin-permissions.rst:169
-#, fuzzy
-#| msgid "``admin.text_module``"
 msgid "``admin.ticket_duplicate_detection``"
-msgstr "``admin.text_module``"
+msgstr "``admin.ticket_duplicate_detection``"
 
 #: ../manage/roles/admin-permissions.rst:170
 msgid ":ref:`Settings > Ticket > Duplicate Detection <duplicate_detection>`"
-msgstr ""
+msgstr ":ref:`Подешавања > Тикет > Откривање дупликата <duplicate_detection>`"
 
 #: ../manage/roles/admin-permissions.rst:172
-#, fuzzy
-#| msgid "``admin.ticket``"
 msgid "``admin.ticket_priority``"
-msgstr "``admin.ticket``"
+msgstr "``admin.ticket_priority``"
 
 #: ../manage/roles/admin-permissions.rst:173
 msgid ":ref:`System > Objects >Ticket Priority <ticket-priority-reference>`"
-msgstr ""
+msgstr ":ref:`Систем > Објекти >Приоритет тикета <ticket-priority-reference>`"
 
 #: ../manage/roles/admin-permissions.rst:175
-#, fuzzy
-#| msgid "``admin.ticket``"
 msgid "``admin.ticket_state``"
-msgstr "``admin.ticket``"
+msgstr "``admin.ticket_state``"
 
 #: ../manage/roles/admin-permissions.rst:176
 msgid ":ref:`System > Objects >Ticket State <ticket-state-reference>`"
-msgstr ""
+msgstr ":ref:`Систем > Објекти > Стање тикета <ticket-state-reference>`"
 
 #: ../manage/roles/admin-permissions.rst:178
 msgid "``admin.time_accounting``"
@@ -10749,16 +10723,12 @@ msgstr ""
 "<view-from-users-perspective>`."
 
 #: ../manage/roles/admin-permissions.rst:193
-#, fuzzy
-#| msgid "``admin.role``"
 msgid "``admin.webhook``"
-msgstr "``admin.role``"
+msgstr "``admin.webhook``"
 
 #: ../manage/roles/admin-permissions.rst:194
-#, fuzzy
-#| msgid ":doc:`Fire a webhook </manage/webhook>`"
 msgid ":doc:`Manage > Webhook </manage/webhook>`"
-msgstr ":doc:`Покрените повратни позив </manage/webhook>`"
+msgstr ":doc:`Управљање > Повратни позив </manage/webhook>`"
 
 #: ../manage/roles/agent-permissions.rst:2
 msgid "Agent Permissions"
@@ -11249,26 +11219,20 @@ msgid "than the user that generated them."
 msgstr "од корисника који их је генерисао."
 
 #: ../manage/roles/user-preferences-permissions.rst:43
-#, fuzzy
-#| msgid "``user_preferences.calendar``"
 msgid "``user_preferences.appearance``"
-msgstr "``user_preferences.calendar``"
+msgstr "``user_preferences.appearance``"
 
 #: ../manage/roles/user-preferences-permissions.rst:44
-#, fuzzy
-#| msgid "Base configuration"
 msgid "Appearance configuration"
-msgstr "Основна подешавања"
+msgstr "Подешавање изгледа"
 
 #: ../manage/roles/user-preferences-permissions.rst:0
 msgid "Users can switch between dark, light and"
-msgstr ""
+msgstr "Корисници могу да изаберу између тамног, светлог и"
 
 #: ../manage/roles/user-preferences-permissions.rst:0
-#, fuzzy
-#| msgid "Automatic Reminders"
 msgid "automatic mode."
-msgstr "Аутоматски подсетници"
+msgstr "аутоматског мода."
 
 #: ../manage/roles/user-preferences-permissions.rst:47
 msgid "``user_preferences.avatar``"
@@ -29461,28 +29425,32 @@ msgstr ""
 "продаје <https://zammad.com/en/company/contact>`_ за више информација."
 
 #: ../system/system-report.rst:2
-#, fuzzy
-#| msgid "System Filters"
 msgid "System Report"
-msgstr "Системски филтери"
+msgstr "Системски извештај"
 
 #: ../system/system-report.rst:4
 msgid ""
 "In this place you can't configure Zammad. Instead you can obtain a system "
 "report about Zammad and its configuration."
 msgstr ""
+"Овде не можете подесити ваш Zammad. Уместо тога можете преузети системски "
+"извештај о Zammad-у и његовој конфигурацији."
 
 #: ../system/system-report.rst:7
 msgid ""
 "See the description in Zammad for an explanation. You can even find a "
 "preview of the included data below the **Download** button."
 msgstr ""
+"Погледајте опис у Zammad-у за објашњење. Можете чак видети и приказ "
+"укључених података испод дугмета **Преузми**."
 
 #: ../system/system-report.rst:10
 msgid ""
 "Zammad never sends this automatically to anyone. It is a manual process only "
 "to provide better support based on your configuration."
 msgstr ""
+"Zammad никада неће аутоматски послати овај извештај икоме. У питању је "
+"мануелни процес само у сврху унапређења подршке на основу ваше конфигурације."
 
 #: ../system/translations.rst:2
 msgid "Translations"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/Admin Documentation (pre-release)](https://translations.zammad.org/projects/documentations/admin-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/admin-documentation-pre-release/horizontal-auto.svg)