### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/cs/LC_MESSAGES/admin-docs.po
+++ b/locale/cs/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2023-09-23 01:11+0000\n"
 "Last-Translator: Tomáš Kovařík <tomas.kovarik@cdv.cz>\n"
 "Language-Team: Czech <https://translations.zammad.org/projects/"
@@ -452,7 +452,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1068,7 +1068,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2574,8 +2574,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2604,7 +2604,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24557,7 +24557,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24565,46 +24565,35 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24616,11 +24605,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24630,138 +24619,138 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr ""
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -24769,13 +24758,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr ""
 
@@ -24783,11 +24772,11 @@ msgstr ""
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 msgid "Ticket Priority"
 msgstr ""
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -24798,11 +24787,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -24812,60 +24801,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/da/LC_MESSAGES/admin-docs.po
+++ b/locale/da/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -430,7 +430,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1046,7 +1046,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2550,8 +2550,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2580,7 +2580,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24519,7 +24519,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24527,46 +24527,35 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24578,11 +24567,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24592,138 +24581,138 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr ""
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -24731,13 +24720,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr ""
 
@@ -24745,11 +24734,11 @@ msgstr ""
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 msgid "Ticket Priority"
 msgstr ""
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -24760,11 +24749,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -24774,60 +24763,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/de/LC_MESSAGES/admin-docs.po
+++ b/locale/de/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2024-12-04 10:00+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
@@ -536,7 +536,7 @@ msgid "Email Inbound"
 msgstr "Eingehende E-Mail"
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr "Typ"
@@ -1294,7 +1294,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr "Notiz"
 
@@ -3149,8 +3149,8 @@ msgstr "Die im Formular nutzbaren Felder sind beschränkt auf die folgenden:"
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr "Name"
 
@@ -3179,7 +3179,7 @@ msgstr "Es gibt Einstellungen für Formulare in Zammad."
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr "Aktiv"
 
@@ -21837,8 +21837,8 @@ msgid ""
 "www.okta.com/>`_)."
 msgstr ""
 "In diesem Fall ist der Dienstanbieter Zammad, und der IdP ist ein "
-"Softwaredienst, den Sie entweder selbst hosten oder abonnieren (z.B. `"
-"Keycloak <https://www.keycloak.org/>`_, `Redhat SSO Server <https://access."
+"Softwaredienst, den Sie entweder selbst hosten oder abonnieren (z.B. "
+"`Keycloak <https://www.keycloak.org/>`_, `Redhat SSO Server <https://access."
 "redhat.com/products/red-hat-single-sign-on>`_, `ADFS <https://docs.microsoft."
 "com/en-us/windows-server/identity/active-directory-federation-services>`_, "
 "oder `Okta <https://www.okta.com/>`_)."
@@ -22364,8 +22364,8 @@ msgid ""
 "Name Identifier Format: ``urn:oasis:names:tc:SAML:1.1:nameid-format:"
 "emailAddress``"
 msgstr ""
-"Name Identifier Format: ``urn:oasis:names:tc:SAML:1.1:nameid-"
-"format:emailAddress``"
+"Name Identifier Format: ``urn:oasis:names:tc:SAML:1.1:nameid-format:"
+"emailAddress``"
 
 #: ../settings/security/third-party/saml/saml-keycloak.rst:60
 #: ../settings/security/third-party/saml/saml-microsoft.rst:62
@@ -22426,8 +22426,8 @@ msgid ""
 "Choose \"Integrate any other application you don't find in the gallery\", "
 "then click \"Create\""
 msgstr ""
-"Wählen Sie \"Integrate any other application you don't find in the gallery\""
-", und klicken Sie dann auf \"Create\""
+"Wählen Sie \"Integrate any other application you don't find in the "
+"gallery\", und klicken Sie dann auf \"Create\""
 
 #: ../settings/security/third-party/saml/saml-microsoft.rst:15
 msgid "2. Configure SAML-based Single Sign-On (SSO)"
@@ -22462,8 +22462,8 @@ msgid ""
 "Reply URL (Assertion Consumer Service URL): Set it to ``https://your.zammad."
 "domain/auth/saml/callback``"
 msgstr ""
-"Reply URL (Assertion Consumer Service URL): Setzen Sie sie auf ``https://ihre"
-".zammad.domain/auth/saml/callback``."
+"Reply URL (Assertion Consumer Service URL): Setzen Sie sie auf ``https://"
+"ihre.zammad.domain/auth/saml/callback``."
 
 #: ../settings/security/third-party/saml/saml-microsoft.rst:27
 msgid "Save the configuration"
@@ -30337,10 +30337,17 @@ msgstr ""
 "Attributen"
 
 #: ../system/objects.rst:58
+#, fuzzy
+#| msgid ""
+#| "When adding or changing attributes, Zammad will not apply the changes "
+#| "instantly, but instead shows you the changed attributes first. If you're "
+#| "ready to go, just click on \"Update database\" to apply the changes to "
+#| "Zammad. If you made a mistake or just want to discard your changes, click "
+#| "\"Discard changes\"."
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -30352,45 +30359,38 @@ msgstr ""
 "verwerfen\"."
 
 #: ../system/objects.rst:64
+#, fuzzy
+#| msgid ""
+#| "After applying the changes with \"Update Database\", a restart of Zammad "
+#| "is **mandatory**. If you don't perform it, you may experience unexpected "
+#| "behavior or even errors. You may want to do this kind of configuration "
+#| "during maintenance windows."
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 "Nach der Übernahme der Änderungen mit \"Datenbank aktualisieren\" ist ein "
 "Neustart von Zammad **zwingend erforderlich**. Wenn Sie dies nicht tun, kann "
 "es zu unerwartetem Verhalten oder sogar zu Fehlern kommen. Sie sollten diese "
 "Art der Konfiguration während eines Wartungsfensters durchführen."
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 "Bei Änderungen an Objekten müssen Sie die Datenbank aktualisieren, um diese "
 "Änderungen zu übernehmen."
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr "**🤓 Neustarts können automatisiert werden**"
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr "Gehostete Instanzen starten automatisch neu."
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-"Wenn Sie eine selbst gehostete Installation verwenden, können Sie :docs:"
-"`Umgebungsvariablen </appendix/configure-env-vars.html>` verwenden"
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr "System-Attribute"
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
@@ -30401,11 +30401,11 @@ msgstr ""
 "bearbeitet werden. Dies ist für den ordnungsgemäßen Betrieb von Zammad "
 "erforderlich und kein Fehler."
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr "Ticket-Status"
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -30422,11 +30422,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr "Screenshot mit hervorgehobenem Ticketstatus-Attribut"
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr "Verwalten von Status"
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -30438,7 +30438,7 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr "Screenshot mit Tabelle der Standard-Ticketstatus"
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
@@ -30449,7 +30449,7 @@ msgstr ""
 "ändern, klicken Sie einfach auf den betreffenden Status. Daraufhin öffnet "
 "sich ein Bearbeitungsdialog."
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
@@ -30459,7 +30459,7 @@ msgstr ""
 "Tickets\" oder \"Standard bei Rückfragen\" setzen, indem Sie auf die "
 "Schaltfläche ⁝ Aktion klicken und die gewünschte Funktion auswählen."
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
@@ -30467,7 +30467,7 @@ msgstr ""
 "*Standard bei neuen Tickets* bedeutet, dass dieser Status für jedes neu "
 "erstellte Ticket verwendet wird."
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
@@ -30475,11 +30475,11 @@ msgstr ""
 "*Standard bei Rückfragen* bedeutet, dass dieser Status verwendet wird, wenn "
 "das Ticket nach seiner Schließung erneut geöffnet wird."
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr "Ticketstatus im Detail"
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
@@ -30488,7 +30488,7 @@ msgstr ""
 "Schauen Sie sich das :ref:`Beispiel <example-state>` an, um den "
 "Bearbeitungsdialog zu sehen."
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
@@ -30496,7 +30496,7 @@ msgstr ""
 "Dies ist der Name des Status und das, was Sie und Ihre Agenten sehen, wenn "
 "sie irgendwo einen Status auswählen (z. B. in Tickets, Triggerkonfiguration)."
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
@@ -30504,27 +30504,27 @@ msgstr ""
 "Es gibt verschiedene Statustypen, aus denen Sie wählen können. Standardmäßig "
 "wird Zammad mit einem Status pro Statustyp ausgeliefert."
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 "**Neu**: für Tickets, die neu sind und an denen noch nicht gearbeitet wurde"
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 "**offen**: für Tickets, die in Bearbeitung sind und an denen Agenten arbeiten"
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 "**zusammengefasst**: für Tickets, die mit anderen Tickets zusammengefasst "
 "werden"
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
@@ -30533,7 +30533,7 @@ msgstr ""
 "Sie eine Erinnerung bekommen möchten. (Standardbeispiel: *Warten auf "
 "Erinnerung*)"
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
@@ -30541,7 +30541,7 @@ msgstr ""
 "**Anstehende Aktion**: für Tickets, die für eine bestimmte Zeit warten und "
 "dann ihren Zustand ändern (Standardbeispiel: *Warten auf Schließung*)"
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
@@ -30549,7 +30549,7 @@ msgstr ""
 "**geschlossen**: für Tickets, die abgeschlossen sind und nicht weiter "
 "bearbeitet werden müssen"
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
@@ -30557,11 +30557,11 @@ msgstr ""
 "⚠️ Die Wahl des richtigen Statustyps ist wichtig! Im Zweifelsfall sollten Sie "
 "einen Blick auf die Standardstatus und ihre Typen werfen!"
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr "Eskalation ignorieren"
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
@@ -30569,7 +30569,7 @@ msgstr ""
 "Hier können Sie festlegen, ob Tickets dieses Status auf die Eskalationszeit "
 "angerechnet werden sollen oder nicht."
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
@@ -30577,11 +30577,11 @@ msgstr ""
 "Sie können eine Notiz für den Status erstellen, um andere Administratoren "
 "über den Status zu informieren. Dies hat keine Auswirkungen auf Tickets."
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr "Setzen Sie den Status auf *aktiv* oder *inaktiv*."
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
@@ -30590,11 +30590,11 @@ msgstr ""
 "Zammad auch in einem solchen Fall funktioniert, wird das Inaktiv-setzen "
 "eines der Status ignoriert."
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr "Beispiel für einen Ticketstatus"
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
@@ -30604,7 +30604,7 @@ msgstr ""
 "das Ticket auf eine Antwort eines Dritten (z.B. eines Dienstleisters oder "
 "Herstellers) warten muss, und wir möchten eine Erinnerung setzen können."
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
@@ -30612,7 +30612,7 @@ msgstr ""
 "Zunächst geben wir dem neuen Zustand einen Namen. In diesem Beispiel nennen "
 "wir ihn \"Warten auf den Hersteller\"."
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -30624,7 +30624,7 @@ msgstr ""
 "Erinnerung kann nützlich sein, wenn unser Hersteller manchmal nicht "
 "antwortet oder wir ihn daran erinnern wollen, uns eine Antwort zu geben."
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
@@ -30632,7 +30632,7 @@ msgstr ""
 "Wir wählen \"nein\" für \"Eskalation ignorieren\", weil wir die Tickets auch "
 "dann eskalieren wollen, wenn wir auf die Rückmeldung des Herstellers warten."
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr "Das **Ergebnis** im Erstellungsdialog sieht dann so aus:"
 
@@ -30640,11 +30640,11 @@ msgstr "Das **Ergebnis** im Erstellungsdialog sieht dann so aus:"
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr "Screenshot zeigt Dialog zur Erstellung eines Ticketstatus mit Beispiel"
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 msgid "Ticket Priority"
 msgstr "Ticket-Priorität"
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -30658,11 +30658,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr "Screenshot mit hervorgehobenem Ticketprioritätsattribut"
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr "Verwalten von Prioritäten"
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -30674,7 +30674,7 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr "Screenshot mit Tabelle der Standard-Ticketprioritäten"
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
@@ -30685,7 +30685,7 @@ msgstr ""
 "ändern, klicken Sie einfach auf die betreffende Priorität. Daraufhin öffnet "
 "sich ein Bearbeitungsdialog."
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
@@ -30694,7 +30694,7 @@ msgstr ""
 "Tickets\" setzen, indem Sie auf die Schaltfläche ⁝ Aktion klicken und die "
 "gewünschte Funktion auswählen."
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
@@ -30702,16 +30702,16 @@ msgstr ""
 "*Standard bei neuen Tickets* bedeutet, dass diese Priorität für jedes neu "
 "erstellte Ticket verwendet wird."
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr "Prioritäten im Detail"
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 "Nachfolgend finden Sie eine Beschreibung für jedes Feld und jede Option."
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
@@ -30720,11 +30720,11 @@ msgstr ""
 "wenn Sie irgendwo eine Priorität auswählen (z.B. in Tickets, Trigger-"
 "Konfiguration)."
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr "Highlight-Farbe"
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
@@ -30733,11 +30733,11 @@ msgstr ""
 "und - (Standard). Dies wirkt sich auf die angezeigte Farbe für Ticket-Titel "
 "in Übersichten aus."
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr "Die Farboptionen sind derzeit auf die genannten Optionen beschränkt."
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
@@ -30745,7 +30745,7 @@ msgstr ""
 "Sie können eine Notiz für die Priorität erstellen, um andere Administratoren "
 "über die Priorität zu informieren. Dies hat keine Auswirkungen auf Tickets."
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr "Setzen Sie die Priorität auf *aktiv* oder *inaktiv*."
 
@@ -33051,6 +33051,19 @@ msgstr "Version"
 msgid "Shows which version is currently being used on your Zammad-instance."
 msgstr ""
 "Zeigt an, welche Version derzeit auf Ihrer Zammad-Instanz verwendet wird."
+
+#~ msgid "**🤓 Service restarts can be automated**"
+#~ msgstr "**🤓 Neustarts können automatisiert werden**"
+
+#~ msgid "Hosted environments automatically restart for you."
+#~ msgstr "Gehostete Instanzen starten automatisch neu."
+
+#~ msgid ""
+#~ "If you're using a self-hosted installation you can use :docs:`environment "
+#~ "variables </appendix/configure-env-vars.html>`"
+#~ msgstr ""
+#~ "Wenn Sie eine selbst gehostete Installation verwenden, können Sie :docs:"
+#~ "`Umgebungsvariablen </appendix/configure-env-vars.html>` verwenden"
 
 #~ msgid ""
 #~ "Connect your SAML (Security Assertion Markup Language) identity provider "

--- a/locale/es/LC_MESSAGES/admin-docs.po
+++ b/locale/es/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2024-10-18 22:00+0000\n"
 "Last-Translator: Marian <mariandilda@gmail.com>\n"
 "Language-Team: Spanish <https://translations.zammad.org/projects/"
@@ -523,7 +523,7 @@ msgid "Email Inbound"
 msgstr "Bandeja de entrada"
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr "Tipo"
@@ -1157,7 +1157,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2688,8 +2688,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2718,7 +2718,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24825,7 +24825,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24833,47 +24833,36 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 #, fuzzy
 msgid "Ticket State"
 msgstr "Ticket > Creado en"
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24885,11 +24874,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24899,140 +24888,140 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 #, fuzzy
 msgid "Ticket state in detail"
 msgstr "Ticket > Cliente > Correo Electrónico"
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 #, fuzzy
 msgid "Ticket state example"
 msgstr "Ticket > Creado en"
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -25040,13 +25029,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 #, fuzzy
 msgid "The **result** in the creation dialog will look like this:"
 msgstr "El resultado final se parecerá a lo siguiente:"
@@ -25055,12 +25044,12 @@ msgstr "El resultado final se parecerá a lo siguiente:"
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 #, fuzzy
 msgid "Ticket Priority"
 msgstr "prioridad"
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -25071,11 +25060,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -25085,60 +25074,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/es_CO/LC_MESSAGES/admin-docs.po
+++ b/locale/es_CO/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -430,7 +430,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1046,7 +1046,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2550,8 +2550,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2580,7 +2580,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24519,7 +24519,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24527,46 +24527,35 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24578,11 +24567,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24592,138 +24581,138 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr ""
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -24731,13 +24720,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr ""
 
@@ -24745,11 +24734,11 @@ msgstr ""
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 msgid "Ticket Priority"
 msgstr ""
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -24760,11 +24749,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -24774,60 +24763,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/es_MX/LC_MESSAGES/admin-docs.po
+++ b/locale/es_MX/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2023-10-11 14:18+0000\n"
 "Last-Translator: morealedgar <morealedgar@gmail.com>\n"
 "Language-Team: Spanish (Mexico) <https://translations.zammad.org/projects/"
@@ -433,7 +433,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1049,7 +1049,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2555,8 +2555,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2585,7 +2585,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24524,7 +24524,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24532,46 +24532,35 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24583,11 +24572,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24597,138 +24586,138 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr ""
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -24736,13 +24725,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr ""
 
@@ -24750,11 +24739,11 @@ msgstr ""
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 msgid "Ticket Priority"
 msgstr ""
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -24765,11 +24754,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -24779,60 +24768,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/fa/LC_MESSAGES/admin-docs.po
+++ b/locale/fa/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2024-11-19 05:00+0000\n"
 "Last-Translator: sesoltani <se.soltani@hotmail.com>\n"
 "Language-Team: Persian <https://translations.zammad.org/projects/"
@@ -461,7 +461,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1077,7 +1077,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2581,8 +2581,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2611,7 +2611,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24560,7 +24560,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24568,46 +24568,35 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24619,11 +24608,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24633,138 +24622,138 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr ""
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -24772,13 +24761,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr ""
 
@@ -24786,11 +24775,11 @@ msgstr ""
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 msgid "Ticket Priority"
 msgstr ""
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -24801,11 +24790,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -24815,60 +24804,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/fr/LC_MESSAGES/admin-docs.po
+++ b/locale/fr/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2024-10-08 00:00+0000\n"
 "Last-Translator: Misha <misha@association-enoria.org>\n"
 "Language-Team: French <https://translations.zammad.org/projects/"
@@ -549,7 +549,7 @@ msgid "Email Inbound"
 msgstr "Boîte de réception"
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr "Type"
@@ -1204,7 +1204,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2738,8 +2738,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2768,7 +2768,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24919,7 +24919,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24927,47 +24927,36 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 #, fuzzy
 msgid "System Attributes"
 msgstr "Variables Article"
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24979,11 +24968,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24993,139 +24982,139 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 #, fuzzy
 msgid "Ticket state example"
 msgstr "exemple"
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -25133,13 +25122,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr ""
 "Le **résultat** final du dialogue de création ressemblera à ce qui suit :"
@@ -25148,12 +25137,12 @@ msgstr ""
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 #, fuzzy
 msgid "Ticket Priority"
 msgstr "priorité"
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -25164,11 +25153,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -25178,60 +25167,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/fr_CA/LC_MESSAGES/admin-docs.po
+++ b/locale/fr_CA/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2021-12-03 14:33+0000\n"
 "Last-Translator: TRANSFER FROM TRANSIFEX <support@zammad.com>\n"
 "Language-Team: French (Canada) <https://translations.zammad.org/projects/"
@@ -467,7 +467,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1084,7 +1084,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2710,8 +2710,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2740,7 +2740,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -25007,7 +25007,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -25015,48 +25015,37 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 #, fuzzy
 msgid "System Attributes"
 msgstr "Attributs d'un billet"
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 #, fuzzy
 msgid "Ticket State"
 msgstr "Billet > État > Nom"
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -25068,11 +25057,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -25082,140 +25071,140 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 #, fuzzy
 msgid "Ticket state in detail"
 msgstr "Billet > État > Nom"
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 #, fuzzy
 msgid "Ticket state example"
 msgstr "Billet > État > Nom"
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -25223,13 +25212,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 #, fuzzy
 msgid "The **result** in the creation dialog will look like this:"
 msgstr "Le résultat final ressemblera à ceci:"
@@ -25238,12 +25227,12 @@ msgstr "Le résultat final ressemblera à ceci:"
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 #, fuzzy
 msgid "Ticket Priority"
 msgstr "Billet > Priorité > Nom"
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -25254,11 +25243,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -25268,60 +25257,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/hr/LC_MESSAGES/admin-docs.po
+++ b/locale/hr/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2022-06-15 13:40+0000\n"
 "Last-Translator: Ivan Perovic <ip@zammad.com>\n"
 "Language-Team: Croatian <https://translations.zammad.org/projects/"
@@ -493,7 +493,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1109,7 +1109,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2616,8 +2616,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2646,7 +2646,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24638,7 +24638,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24646,46 +24646,35 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24697,11 +24686,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24711,138 +24700,138 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr ""
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -24850,13 +24839,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 #, fuzzy
 msgid "The **result** in the creation dialog will look like this:"
 msgstr "Krajnji rezultat će izgledati ovako:"
@@ -24865,12 +24854,12 @@ msgstr "Krajnji rezultat će izgledati ovako:"
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 #, fuzzy
 msgid "Ticket Priority"
 msgstr "prioritet"
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -24881,11 +24870,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -24895,60 +24884,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/hu/LC_MESSAGES/admin-docs.po
+++ b/locale/hu/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -430,7 +430,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1046,7 +1046,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2550,8 +2550,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2580,7 +2580,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24519,7 +24519,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24527,46 +24527,35 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24578,11 +24567,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24592,138 +24581,138 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr ""
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -24731,13 +24720,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr ""
 
@@ -24745,11 +24734,11 @@ msgstr ""
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 msgid "Ticket Priority"
 msgstr ""
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -24760,11 +24749,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -24774,60 +24763,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/it/LC_MESSAGES/admin-docs.po
+++ b/locale/it/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2023-04-15 10:17+0000\n"
 "Last-Translator: crnfpp <crnfpp@unife.it>\n"
 "Language-Team: Italian <https://translations.zammad.org/projects/"
@@ -439,7 +439,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1055,7 +1055,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2561,8 +2561,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2591,7 +2591,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24547,7 +24547,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24555,46 +24555,35 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24606,11 +24595,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24620,138 +24609,138 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr ""
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -24759,13 +24748,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr ""
 
@@ -24773,11 +24762,11 @@ msgstr ""
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 msgid "Ticket Priority"
 msgstr ""
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -24788,11 +24777,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -24802,60 +24791,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/nl/LC_MESSAGES/admin-docs.po
+++ b/locale/nl/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -430,7 +430,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1046,7 +1046,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2550,8 +2550,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2580,7 +2580,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24519,7 +24519,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24527,46 +24527,35 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24578,11 +24567,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24592,138 +24581,138 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr ""
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -24731,13 +24720,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr ""
 
@@ -24745,11 +24734,11 @@ msgstr ""
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 msgid "Ticket Priority"
 msgstr ""
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -24760,11 +24749,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -24774,60 +24763,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/pl/LC_MESSAGES/admin-docs.po
+++ b/locale/pl/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2024-06-20 06:00+0000\n"
 "Last-Translator: MBekspert <michal.bosak@ekspert.biz>\n"
 "Language-Team: Polish <https://translations.zammad.org/projects/"
@@ -434,7 +434,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1050,7 +1050,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2555,8 +2555,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2585,7 +2585,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24546,7 +24546,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24554,46 +24554,35 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24605,11 +24594,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24619,138 +24608,138 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr ""
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -24758,13 +24747,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr ""
 
@@ -24772,12 +24761,12 @@ msgstr ""
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 #, fuzzy
 msgid "Ticket Priority"
 msgstr "priorytet"
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -24788,11 +24777,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -24802,60 +24791,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/pt_BR/LC_MESSAGES/admin-docs.po
+++ b/locale/pt_BR/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2024-03-10 08:00+0000\n"
 "Last-Translator: Glauber Daniel Ribeiro <glauberdribeiro@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://translations.zammad.org/projects/"
@@ -492,7 +492,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1110,7 +1110,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2635,8 +2635,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2665,7 +2665,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -25032,7 +25032,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -25040,48 +25040,37 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 #, fuzzy
 msgid "System Attributes"
 msgstr "Atributos do ticket"
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 #, fuzzy
 msgid "Ticket State"
 msgstr "Atributos do ticket"
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -25093,11 +25082,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -25107,140 +25096,140 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 #, fuzzy
 msgid "Set the state to *active* or *inactive*."
 msgstr "Se está ativo ou inativo"
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 #, fuzzy
 msgid "Ticket state example"
 msgstr "Árvore de Seleção"
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -25248,13 +25237,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 #, fuzzy
 msgid "The **result** in the creation dialog will look like this:"
 msgstr "O resultado final parecerá como o seguinte:"
@@ -25263,12 +25252,12 @@ msgstr "O resultado final parecerá como o seguinte:"
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 #, fuzzy
 msgid "Ticket Priority"
 msgstr "Prioridade"
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -25279,11 +25268,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -25293,60 +25282,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 #, fuzzy
 msgid "Set the priority to *active* or *inactive*."
 msgstr "Se está ativo ou inativo"

--- a/locale/ru/LC_MESSAGES/admin-docs.po
+++ b/locale/ru/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2024-10-16 13:00+0000\n"
 "Last-Translator: Nikita <nyakovlev@iko.tech>\n"
 "Language-Team: Russian <https://translations.zammad.org/projects/"
@@ -464,7 +464,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1080,7 +1080,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2586,8 +2586,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2616,7 +2616,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24575,7 +24575,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24583,46 +24583,35 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24634,11 +24623,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24648,138 +24637,138 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr ""
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -24787,13 +24776,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr ""
 
@@ -24801,11 +24790,11 @@ msgstr ""
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 msgid "Ticket Priority"
 msgstr ""
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -24816,11 +24805,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -24830,60 +24819,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/sr/LC_MESSAGES/admin-docs.po
+++ b/locale/sr/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad Admin Documentation pre-release\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2024-12-04 10:00+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
@@ -518,7 +518,7 @@ msgid "Email Inbound"
 msgstr "Долазни имејл"
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr "Тип"
@@ -1244,7 +1244,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr "Напомена"
 
@@ -3075,8 +3075,8 @@ msgstr "Поља наведена у форми су ограничена на �
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr "Назив"
 
@@ -3105,7 +3105,7 @@ msgstr "Zammad долази са одређеним подешавањима з�
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr "Активно"
 
@@ -21235,11 +21235,11 @@ msgid ""
 "www.okta.com/>`_)."
 msgstr ""
 "У овом случају, сервисни провајдер је Zammad, а IdP је софтверски сервис "
-"који или хостујете сами или се претплатите на њега (нпр. `Keycloak "
-"<https://www.keycloak.org/>`_, `Redhat SSO Server <https://access.redhat.com/"
-"products/red-hat-single-sign-on>`_, `ADFS <https://docs.microsoft.com/en-us/"
-"windows-server/identity/active-directory-federation-services>`_ или `Okta "
-"<https://www.okta.com/>` _)."
+"који или хостујете сами или се претплатите на њега (нпр. `Keycloak <https://"
+"www.keycloak.org/>`_, `Redhat SSO Server <https://access.redhat.com/products/"
+"red-hat-single-sign-on>`_, `ADFS <https://docs.microsoft.com/en-us/windows-"
+"server/identity/active-directory-federation-services>`_ или `Okta <https://"
+"www.okta.com/>` _)."
 
 #: ../settings/security/third-party/saml.rst:19
 msgid ""
@@ -21720,8 +21720,8 @@ msgid ""
 "In the admin panel go to \"Settings\" > \"Security\" > \"Third-party "
 "Applications\" > \"Authentication via SAML\""
 msgstr ""
-"Идите у администраторском панелу на „Подешавања” > „Безбедност” > „"
-"Апликације трећег лица” > „Аутентификација путем SAML”"
+"Идите у администраторском панелу на „Подешавања” > „Безбедност” > "
+"„Апликације трећег лица” > „Аутентификација путем SAML”"
 
 #: ../settings/security/third-party/saml/saml-keycloak.rst:54
 #: ../settings/security/third-party/saml/saml-microsoft.rst:56
@@ -21746,8 +21746,8 @@ msgid ""
 "Name Identifier Format: ``urn:oasis:names:tc:SAML:1.1:nameid-format:"
 "emailAddress``"
 msgstr ""
-"Формат идентификатора назива: ``urn:oasis:names:tc:SAML:1.1:nameid-"
-"format:emailAddress``"
+"Формат идентификатора назива: ``urn:oasis:names:tc:SAML:1.1:nameid-format:"
+"emailAddress``"
 
 #: ../settings/security/third-party/saml/saml-keycloak.rst:60
 #: ../settings/security/third-party/saml/saml-microsoft.rst:62
@@ -21788,7 +21788,8 @@ msgstr "Идите на „Identity” > „Applications” > „Enterprise Appl
 
 #: ../settings/security/third-party/saml/saml-microsoft.rst:9
 msgid "Click \"New Application\" and select \"Create your own application\""
-msgstr "Кликните на „New Application” и одаберите „Create your own application”"
+msgstr ""
+"Кликните на „New Application” и одаберите „Create your own application”"
 
 #: ../settings/security/third-party/saml/saml-microsoft.rst:10
 msgid "Enter a name for the application, e.g. \"Zammad SAML Integration\""
@@ -21835,8 +21836,8 @@ msgid ""
 "Reply URL (Assertion Consumer Service URL): Set it to ``https://your.zammad."
 "domain/auth/saml/callback``"
 msgstr ""
-"URL адреса одговора (Assertion Consumer Service URL): поставите на "
-"``https://your.zammad.domain/auth/saml/callback``"
+"URL адреса одговора (Assertion Consumer Service URL): поставите на ``https://"
+"your.zammad.domain/auth/saml/callback``"
 
 #: ../settings/security/third-party/saml/saml-microsoft.rst:27
 msgid "Save the configuration"
@@ -29442,10 +29443,17 @@ msgid "Updating Database After Adding or Editing Attributes"
 msgstr "Освежавање базе података након додавања или уређивања атрибута"
 
 #: ../system/objects.rst:58
+#, fuzzy
+#| msgid ""
+#| "When adding or changing attributes, Zammad will not apply the changes "
+#| "instantly, but instead shows you the changed attributes first. If you're "
+#| "ready to go, just click on \"Update database\" to apply the changes to "
+#| "Zammad. If you made a mistake or just want to discard your changes, click "
+#| "\"Discard changes\"."
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -29455,45 +29463,38 @@ msgstr ""
 "погрешили или само желите да одбаците промене, кликните на „Откажи промене“."
 
 #: ../system/objects.rst:64
+#, fuzzy
+#| msgid ""
+#| "After applying the changes with \"Update Database\", a restart of Zammad "
+#| "is **mandatory**. If you don't perform it, you may experience unexpected "
+#| "behavior or even errors. You may want to do this kind of configuration "
+#| "during maintenance windows."
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 "Након примене измена путем „Освежи базу података“, поновно покретање Zammad-"
 "ових сервиса је **обавезно**. Ако то не урадите, можете доћи у неочекивану "
 "ситуацију или чак узроковати грешке. Можда ћете желети да одрадите оваква "
 "подешавања током режима одржавања."
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 "Измене на објектима захтевају да освежите базу података да бисте применили "
 "ове измене."
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr "**🤓 Поновно покретање сервиса се може аутоматизовати**"
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr "Хостована окружења се аутоматски рестартују за вас."
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-"Ако користите инсталацију коју сами хостујете, можете користити :docs:"
-"`променљиве окружења </appendix/configure-env-vars.html>`."
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr "Системски атрибути"
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
@@ -29504,11 +29505,11 @@ msgstr ""
 "атрибути су обавезни за исправно функционисање Zammad-а и није у питању "
 "грешка."
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr "Стање тикета"
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -29524,11 +29525,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr "Снимак екрана који приказује наглашен атрибут стања тикета"
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr "Руковање стањима"
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -29540,7 +29541,7 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr "Снимак екрана који приказује табелу подразумеваних стања тикета"
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
@@ -29550,7 +29551,7 @@ msgstr ""
 "углу. За измену постојећег стања, једноставно кликните на дотично стање. Ово "
 "ће отворити дијалог за уређивање."
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
@@ -29560,7 +29561,7 @@ msgstr ""
 "тикете” или „подразумевано за наставке” кликом на ⁝ дугме радњи и одабиром "
 "жељене функције."
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
@@ -29568,7 +29569,7 @@ msgstr ""
 "*Подразумевано за нове тикете* значи да ће ово стање бити коришћено за све "
 "новоотворене тикете."
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
@@ -29576,11 +29577,11 @@ msgstr ""
 "*Подразумевано за наставке* значи да ће ово стање бити коришћено уколико се "
 "тикет поново отвори након што је био затворен."
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr "Детаљније о стању тикета"
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
@@ -29588,7 +29589,7 @@ msgstr ""
 "Испод можете пронаћи опис сваког поља и опције. Идите на :ref:`пример "
 "<example-state>` да бисте видели како изгледа дијалог за уређивање."
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
@@ -29596,7 +29597,7 @@ msgstr ""
 "Ово је назив стања и шта ви и ваши оператери видите када негде бирате стање "
 "(нпр. у тикетима, подешавању окидача)."
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
@@ -29604,24 +29605,24 @@ msgstr ""
 "Има више различитих типова стања које можете одабрати. Подразумевано, Zammad "
 "долази са једним стањем по сваком типу стања."
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr "**ново**: за стања тикета који су нови и који још увек нису обрађени"
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 "**отворено**: за стања тикета који су у процесу и оператери раде на њима"
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr "**спојено**: за стања тикета који су спојени са другим тикетима"
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
@@ -29629,7 +29630,7 @@ msgstr ""
 "**чека на подсетник**: за стања тикета који су у процесу и за које желите да "
 "поставите подсетник. (подразумевани пример: *чека на подсетник*)"
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
@@ -29637,7 +29638,7 @@ msgstr ""
 "**радња на чекању**: за стања тикета који чекају на одређено време и тада "
 "мењају своје стање (подразумевани пример: *чека на затварање*)"
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
@@ -29645,7 +29646,7 @@ msgstr ""
 "**затворено**: за стања тикета који су обрађени и које више није неопходно "
 "процесуирати"
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
@@ -29653,11 +29654,11 @@ msgstr ""
 "⚠️ Важно је одабрати исправан тип стања! Ако сумњате у свој избор, погледајте "
 "подразумевана стања и њихове типове!"
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr "Игнориши ескалације"
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
@@ -29665,7 +29666,7 @@ msgstr ""
 "Овде можете одредити да ли ће се тикети у овом стању рачунати за време "
 "ескалације."
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
@@ -29673,11 +29674,11 @@ msgstr ""
 "Можете додати напомену за стање да бисте обавестили друге администраторе о "
 "овом стању. Ово нема ефекта на тикете."
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr "Поставите стање на *укључено* или *искључено*."
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
@@ -29686,11 +29687,11 @@ msgstr ""
 "настави да функционише, једно од искључених стања ће бити аутоматски "
 "активирано."
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr "Пример стања тикета"
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
@@ -29700,7 +29701,7 @@ msgstr ""
 "чека на одговор трећег лица (нпр. подизвођача или произвођача) и желимо да "
 "поставимо подсетник."
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
@@ -29708,7 +29709,7 @@ msgstr ""
 "Прво дајемо назив новом стању. У овом примеру називамо га „чека на "
 "произвођача”."
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -29720,7 +29721,7 @@ msgstr ""
 "уколико наш произвођач понекад не реагује или желимо да их подсетимо за нам "
 "доставе одговор."
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
@@ -29728,7 +29729,7 @@ msgstr ""
 "Одабиремо „не” за „игнориши ескалације” зато што желимо да ескалирамо тикете "
 "чак иако чекамо на одговор произвођача."
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr "**Резултат** у дијалогу новог тикета ће изгледати овако:"
 
@@ -29738,11 +29739,11 @@ msgstr ""
 "Снимак екрана који приказује дијалог за додавање новог стања тикета са "
 "примером"
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 msgid "Ticket Priority"
 msgstr "Приоритет тикета"
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -29756,11 +29757,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr "Снимак екрана који приказује наглашен атрибут приоритета тикета"
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr "Руковање приоритетима"
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -29772,7 +29773,7 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr "Снимак екрана који приказује табелу подразумеваних приоритета тикета"
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
@@ -29782,7 +29783,7 @@ msgstr ""
 "десном углу. За измену постојећег приоритета, једноставно кликните на "
 "дотични приоритет. Ово ће отворити дијалог за уређивање."
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
@@ -29790,7 +29791,7 @@ msgstr ""
 "Такође можете клонирати приоритет или га поставити на „подразумевано за нове "
 "тикете” кликом на ⁝ дугме радњи и одабиром жељене функције."
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
@@ -29798,15 +29799,15 @@ msgstr ""
 "*Подразумевано за нове тикете* значи да ће овај приоритет бити коришћен за "
 "све новоотворене тикете."
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr "Детаљније о приоритетима"
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr "Испод можете наћи опис сваког поља и опције."
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
@@ -29814,11 +29815,11 @@ msgstr ""
 "Ово је назив приоритета и шта ви и ваши оператери видите када негде бирате "
 "приоритет (нпр. у тикетима, подешавању окидача)."
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr "Боја истицања"
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
@@ -29827,11 +29828,11 @@ msgstr ""
 "(црвена) и - (подразумевано). Ово утиче на боју приказа наслова тикета у "
 "прегледима."
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr "Доступне боје су тренутно ограничене на поменуте опције."
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
@@ -29839,7 +29840,7 @@ msgstr ""
 "Можете додати напомену за приоритет да бисте обавестили друге администраторе "
 "о овом приоритету. Ово нема ефекта на тикете."
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr "Поставите приоритет на *укључено* или *искључено*."
 
@@ -32070,6 +32071,19 @@ msgstr "Верзија"
 #: ../system/version.rst:4
 msgid "Shows which version is currently being used on your Zammad-instance."
 msgstr "Приказује која верзија се користи тренутно на вашој Zammad инстанци."
+
+#~ msgid "**🤓 Service restarts can be automated**"
+#~ msgstr "**🤓 Поновно покретање сервиса се може аутоматизовати**"
+
+#~ msgid "Hosted environments automatically restart for you."
+#~ msgstr "Хостована окружења се аутоматски рестартују за вас."
+
+#~ msgid ""
+#~ "If you're using a self-hosted installation you can use :docs:`environment "
+#~ "variables </appendix/configure-env-vars.html>`"
+#~ msgstr ""
+#~ "Ако користите инсталацију коју сами хостујете, можете користити :docs:"
+#~ "`променљиве окружења </appendix/configure-env-vars.html>`."
 
 #~ msgid ""
 #~ "Connect your SAML (Security Assertion Markup Language) identity provider "

--- a/locale/sv/LC_MESSAGES/admin-docs.po
+++ b/locale/sv/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2024-10-25 11:00+0000\n"
 "Last-Translator: chrand818 <can@telenabler.com>\n"
 "Language-Team: Swedish <https://translations.zammad.org/projects/"
@@ -436,7 +436,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1052,7 +1052,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2557,8 +2557,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2587,7 +2587,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24542,7 +24542,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24550,46 +24550,35 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24601,11 +24590,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24615,138 +24604,138 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr ""
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -24754,13 +24743,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr ""
 
@@ -24768,11 +24757,11 @@ msgstr ""
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 msgid "Ticket Priority"
 msgstr ""
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -24783,11 +24772,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -24797,60 +24786,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/th/LC_MESSAGES/admin-docs.po
+++ b/locale/th/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -430,7 +430,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr ""
@@ -1046,7 +1046,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2550,8 +2550,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2580,7 +2580,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24519,7 +24519,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24527,46 +24527,35 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24578,11 +24567,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24592,138 +24581,138 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr ""
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -24731,13 +24720,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 msgid "The **result** in the creation dialog will look like this:"
 msgstr ""
 
@@ -24745,11 +24734,11 @@ msgstr ""
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 msgid "Ticket Priority"
 msgstr ""
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -24760,11 +24749,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -24774,60 +24763,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 

--- a/locale/tr/LC_MESSAGES/admin-docs.po
+++ b/locale/tr/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2024-09-27 17:00+0000\n"
 "Last-Translator: Rob <robertborge@outlook.com>\n"
 "Language-Team: Turkish <https://translations.zammad.org/projects/"
@@ -514,7 +514,7 @@ msgid "Email Inbound"
 msgstr ""
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr "Tür"
@@ -1160,7 +1160,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr "Not"
 
@@ -2754,8 +2754,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 #, fuzzy
 msgid "Name"
 msgstr "Ad:"
@@ -2786,7 +2786,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr "Aktif"
 
@@ -25802,7 +25802,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -25810,48 +25810,37 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 #, fuzzy
 msgid "System Attributes"
 msgstr "Bilet nitelikleri"
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 #, fuzzy
 msgid "Ticket State"
 msgstr "Bilet > Durum > Ad"
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -25863,12 +25852,12 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 #, fuzzy
 msgid "Handling of states"
 msgstr "Makro Yönetimi"
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -25878,141 +25867,141 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 #, fuzzy
 msgid "Ticket state in detail"
 msgstr "Bilet > Durum > Ad"
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 #, fuzzy
 msgid "Set the state to *active* or *inactive*."
 msgstr "aktifse veya değilse"
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 #, fuzzy
 msgid "Ticket state example"
 msgstr "Bilet > Durum > Ad"
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -26020,13 +26009,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 #, fuzzy
 msgid "The **result** in the creation dialog will look like this:"
 msgstr "Final sonuçları aşağıdaki gibi görünecek:"
@@ -26035,12 +26024,12 @@ msgstr "Final sonuçları aşağıdaki gibi görünecek:"
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 #, fuzzy
 msgid "Ticket Priority"
 msgstr "Bilet > Öncelik > Ad"
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -26051,11 +26040,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -26065,60 +26054,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 #, fuzzy
 msgid "Set the priority to *active* or *inactive*."
 msgstr "aktifse veya değilse"

--- a/locale/zh_Hans/LC_MESSAGES/admin-docs.po
+++ b/locale/zh_Hans/LC_MESSAGES/admin-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-29 15:26+0100\n"
+"POT-Creation-Date: 2024-12-17 13:20+0100\n"
 "PO-Revision-Date: 2023-08-14 12:18+0000\n"
 "Last-Translator: chen <chenchen@4chian.com>\n"
 "Language-Team: Chinese (Simplified) <https://translations.zammad.org/"
@@ -496,7 +496,7 @@ msgid "Email Inbound"
 msgstr "电子邮件入站"
 
 #: ../channels/email/accounts/account-setup.rst:110
-#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:154
+#: ../misc/object-conditions/basics.rst:193 ../system/objects.rst:152
 #: ../system/objects/types.rst:157
 msgid "Type"
 msgstr "类型"
@@ -1123,7 +1123,7 @@ msgstr ""
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:18
 #: ../system/integrations/cti/includes/inbound-calls.include.rst:14
 #: ../system/integrations/cti/includes/outbound-calls.include.rst:17
-#: ../system/objects.rst:162 ../system/objects.rst:246
+#: ../system/objects.rst:160 ../system/objects.rst:244
 msgid "Note"
 msgstr ""
 
@@ -2630,8 +2630,8 @@ msgstr ""
 
 #: ../channels/form.rst:19 ../manage/groups/settings.rst:16
 #: ../manage/scheduler.rst:39 ../manage/slas/how-do-they-work.rst:26
-#: ../manage/templates.rst:33 ../system/objects.rst:130
-#: ../system/objects.rst:234
+#: ../manage/templates.rst:33 ../system/objects.rst:128
+#: ../system/objects.rst:232
 msgid "Name"
 msgstr ""
 
@@ -2660,7 +2660,7 @@ msgstr ""
 #: ../manage/macros/how-do-they-work.rst:0 ../manage/overviews.rst:0
 #: ../manage/roles/index.rst:128 ../manage/scheduler.rst:111
 #: ../manage/templates.rst:43 ../manage/webhook/add.rst:123
-#: ../system/objects.rst:169 ../system/objects.rst:248
+#: ../system/objects.rst:167 ../system/objects.rst:246
 msgid "Active"
 msgstr ""
 
@@ -24652,7 +24652,7 @@ msgstr ""
 msgid ""
 "When adding or changing attributes, Zammad will not apply the changes "
 "instantly, but instead shows you the changed attributes first. If you're "
-"ready to go, just click on \"Update database\" to apply the changes to "
+"ready to go, just click on \"Update Database\" to apply the changes to "
 "Zammad. If you made a mistake or just want to discard your changes, click "
 "\"Discard changes\"."
 msgstr ""
@@ -24660,46 +24660,35 @@ msgstr ""
 #: ../system/objects.rst:64
 msgid ""
 "After applying the changes with \"Update Database\", a restart of Zammad is "
-"**mandatory**. If you don't perform it, you may experience unexpected "
-"behavior or even errors. You may want to do this kind of configuration "
-"during maintenance windows."
+"**mandatory**. In most cases, the restart of the service works out of the "
+"box (see :docs:`console commands </admin/console/zammad-settings.html>` for "
+"more information). However, if your system is configured differently and you "
+"don't perform the restart, you may experience unexpected behavior or even "
+"errors. You may want to do this kind of configuration during maintenance "
+"windows."
 msgstr ""
 
-#: ../system/objects.rst:72
+#: ../system/objects.rst:76
 msgid ""
 "Changes on objects require you to update the database to apply these changes."
 msgstr ""
 
-#: ../system/objects.rst:75
-msgid "**🤓 Service restarts can be automated**"
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid "Hosted environments automatically restart for you."
-msgstr ""
-
-#: ../system/objects.rst:0
-msgid ""
-"If you're using a self-hosted installation you can use :docs:`environment "
-"variables </appendix/configure-env-vars.html>`"
-msgstr ""
-
-#: ../system/objects.rst:82
+#: ../system/objects.rst:80
 msgid "System Attributes"
 msgstr ""
 
-#: ../system/objects.rst:84
+#: ../system/objects.rst:82
 msgid ""
 "Zammad comes with pre-configured attributes. Some of them can't be edited "
 "via UI (or at all). This is required for proper operation of Zammad and not "
 "a bug."
 msgstr ""
 
-#: ../system/objects.rst:90
+#: ../system/objects.rst:88
 msgid "Ticket State"
 msgstr ""
 
-#: ../system/objects.rst:92
+#: ../system/objects.rst:90
 msgid ""
 "If the pre-configured states aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the state row in the "
@@ -24711,11 +24700,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket state attribute"
 msgstr ""
 
-#: ../system/objects.rst:122
+#: ../system/objects.rst:120
 msgid "Handling of states"
 msgstr ""
 
-#: ../system/objects.rst:102
+#: ../system/objects.rst:100
 msgid ""
 "In the state configuration screen, you can add new states, disable states or "
 "change states."
@@ -24725,138 +24714,138 @@ msgstr ""
 msgid "Screenshot showing table of default ticket states"
 msgstr ""
 
-#: ../system/objects.rst:110
+#: ../system/objects.rst:108
 msgid ""
 "To add a new state, click on the \"New Ticket State\" button in the top "
 "right corner. To change an existing state, simply click on the affected "
 "state. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:114
+#: ../system/objects.rst:112
 msgid ""
 "You can also clone a state or set them to \"Default for new tickets\" or "
 "\"Default for follow-ups\" by clicking on the ⁝ action button and select the "
 "desired function."
 msgstr ""
 
-#: ../system/objects.rst:118
+#: ../system/objects.rst:116
 msgid ""
 "*Default for new tickets* means that this state is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:121
+#: ../system/objects.rst:119
 msgid ""
 "*Default for follow-ups* means that this state is used if the ticket is re-"
 "opened after it was closed."
 msgstr ""
 
-#: ../system/objects.rst:171
+#: ../system/objects.rst:169
 msgid "Ticket state in detail"
 msgstr ""
 
-#: ../system/objects.rst:125
+#: ../system/objects.rst:123
 msgid ""
 "Below you can find a description for each field and option. Please head over "
 "to the :ref:`example <example-state>` to see the edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:129
+#: ../system/objects.rst:127
 msgid ""
 "This is the name of the state and what you and your agents are seeing when "
 "choosing a state somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:137
+#: ../system/objects.rst:135
 msgid ""
 "There are different state types you can choose from. By default, Zammad "
 "comes with one state per state type."
 msgstr ""
 
-#: ../system/objects.rst:140
+#: ../system/objects.rst:138
 msgid ""
 "**new**: for states for tickets that are new and it hasn't been worked on "
 "them"
 msgstr ""
 
-#: ../system/objects.rst:142
+#: ../system/objects.rst:140
 msgid ""
 "**open**: for states for tickets that are in progress and agents are working "
 "on them"
 msgstr ""
 
-#: ../system/objects.rst:144
+#: ../system/objects.rst:142
 msgid "**merged**: for states for tickets that are merged with other tickets"
 msgstr ""
 
-#: ../system/objects.rst:145
+#: ../system/objects.rst:143
 msgid ""
 "**pending reminder**: for states for tickets that are in progress and you "
 "want to set a reminder. (default example: *pending reminder*)"
 msgstr ""
 
-#: ../system/objects.rst:147
+#: ../system/objects.rst:145
 msgid ""
 "**pending action**: for states for tickets that are waiting for a specified "
 "time and then change their state (default example: *pending close*)"
 msgstr ""
 
-#: ../system/objects.rst:150
+#: ../system/objects.rst:148
 msgid ""
 "**closed**: for states for tickets that are finished and do not need to be "
 "processed further"
 msgstr ""
 
-#: ../system/objects.rst:153
+#: ../system/objects.rst:151
 msgid ""
 "⚠️ Choosing the correct state type is important! If you are in doubt, have a "
 "look on the default states and their types!"
 msgstr ""
 
-#: ../system/objects.rst:158
+#: ../system/objects.rst:156
 msgid "Ignore escalation"
 msgstr ""
 
-#: ../system/objects.rst:157
+#: ../system/objects.rst:155
 msgid ""
 "Here you can define whether tickets of this state will count to escalation "
 "time or not."
 msgstr ""
 
-#: ../system/objects.rst:161
+#: ../system/objects.rst:159
 msgid ""
 "You can create a note for the state to inform other admins about the state. "
 "This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:165
+#: ../system/objects.rst:163
 msgid "Set the state to *active* or *inactive*."
 msgstr ""
 
-#: ../system/objects.rst:167
+#: ../system/objects.rst:165
 msgid ""
 "it is technically possible to set all states to inactive. To keep Zammad "
 "working in such a case, the inactive flag of one of the states is ignored."
 msgstr ""
 
-#: ../system/objects.rst:194
+#: ../system/objects.rst:192
 msgid "Ticket state example"
 msgstr ""
 
-#: ../system/objects.rst:174
+#: ../system/objects.rst:172
 msgid ""
 "Let's assume we want to create a new state which indicates that the ticket "
 "has to wait for a response of a third party (e.g. service contractor or "
 "manufacturer) and we want to to be able to set a reminder."
 msgstr ""
 
-#: ../system/objects.rst:178
+#: ../system/objects.rst:176
 msgid ""
 "First we give the new state a proper name. In this example we call it "
 "\"waiting for manufacturer\"."
 msgstr ""
 
-#: ../system/objects.rst:181
+#: ../system/objects.rst:179
 msgid ""
 "As state type we choose \"pending reminder\". This indicates that the ticket "
 "is still open and we can set a reminder. This reminder can be useful if our "
@@ -24864,13 +24853,13 @@ msgid ""
 "an answer."
 msgstr ""
 
-#: ../system/objects.rst:186
+#: ../system/objects.rst:184
 msgid ""
 "We choose \"no\" for \"ignore escalation\" because we want to escalate the "
 "tickets even if we are waiting on the manufacturer's feedback."
 msgstr ""
 
-#: ../system/objects.rst:189
+#: ../system/objects.rst:187
 #, fuzzy
 msgid "The **result** in the creation dialog will look like this:"
 msgstr "最终结果将如下所示："
@@ -24879,12 +24868,12 @@ msgstr "最终结果将如下所示："
 msgid "Screenshot showing ticket state creation dialog with example"
 msgstr ""
 
-#: ../system/objects.rst:199
+#: ../system/objects.rst:197
 #, fuzzy
 msgid "Ticket Priority"
 msgstr "优先级"
 
-#: ../system/objects.rst:201
+#: ../system/objects.rst:199
 msgid ""
 "If the pre-configured priorities aren't enough for you or you want to change "
 "them, you can do so by clicking on the cogwheel icon in the priority row in "
@@ -24895,11 +24884,11 @@ msgstr ""
 msgid "Screenshot showing highlighted ticket priority attribute"
 msgstr ""
 
-#: ../system/objects.rst:226
+#: ../system/objects.rst:224
 msgid "Handling of priorities"
 msgstr ""
 
-#: ../system/objects.rst:210
+#: ../system/objects.rst:208
 msgid ""
 "In the priority configuration screen, you can add new priorities, disable "
 "priorities or change priorities."
@@ -24909,60 +24898,60 @@ msgstr ""
 msgid "Screenshot showing table of default ticket priorities"
 msgstr ""
 
-#: ../system/objects.rst:218
+#: ../system/objects.rst:216
 msgid ""
 "To add a new priority, click on the \"New Priority\" button in the top right "
 "corner. To change an existing priority, simply click on the affected "
 "priority. This opens an edit dialog."
 msgstr ""
 
-#: ../system/objects.rst:222
+#: ../system/objects.rst:220
 msgid ""
 "You can also clone a priority or set them to \"Default for new tickets\" by "
 "clicking on the ⁝ action button and select the desired function."
 msgstr ""
 
-#: ../system/objects.rst:225
+#: ../system/objects.rst:223
 msgid ""
 "*Default for new tickets* means that this priority is used for every newly "
 "created ticket."
 msgstr ""
 
-#: ../system/objects.rst:248
+#: ../system/objects.rst:246
 msgid "Priorities in detail"
 msgstr ""
 
-#: ../system/objects.rst:229
+#: ../system/objects.rst:227
 msgid "Below you can find a description for each field and option."
 msgstr ""
 
-#: ../system/objects.rst:232
+#: ../system/objects.rst:230
 msgid ""
 "This is the name of the priority and what you and your agents are seeing "
 "when choosing a priority somewhere (e.g. in tickets, trigger configuration)."
 msgstr ""
 
-#: ../system/objects.rst:242
+#: ../system/objects.rst:240
 msgid "Highlight color"
 msgstr ""
 
-#: ../system/objects.rst:237
+#: ../system/objects.rst:235
 msgid ""
 "Switch between *Low priority* (light blue), *High priority* (red) and - "
 "(default). This affects the displayed color for ticket titles in overviews."
 msgstr ""
 
-#: ../system/objects.rst:241
+#: ../system/objects.rst:239
 msgid "The color options are currently limited to the mentioned options."
 msgstr ""
 
-#: ../system/objects.rst:245
+#: ../system/objects.rst:243
 msgid ""
 "You can create a note for the priority to inform other admins about the "
 "priority. This has no effect on tickets."
 msgstr ""
 
-#: ../system/objects.rst:249
+#: ../system/objects.rst:247
 msgid "Set the priority to *active* or *inactive*."
 msgstr ""
 


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/Admin Documentation (pre-release)](https://translations.zammad.org/projects/documentations/admin-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/admin-documentation-pre-release/horizontal-auto.svg)