### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/it/LC_MESSAGES/admin-docs.po
+++ b/locale/it/LC_MESSAGES/admin-docs.po
@@ -8,16 +8,16 @@ msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-28 13:09+0100\n"
-"PO-Revision-Date: 2023-04-15 10:17+0000\n"
-"Last-Translator: crnfpp <crnfpp@unife.it>\n"
+"PO-Revision-Date: 2025-03-25 10:00+0000\n"
+"Last-Translator: lenny76 <lenny76@lenny76.com>\n"
 "Language-Team: Italian <https://translations.zammad.org/projects/"
-"documentations/admin-documentation/it/>\n"
+"documentations/admin-documentation-pre-release/it/>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.16.4\n"
+"X-Generator: Weblate 5.9.2\n"
 
 #: ../channels/chat.rst:2 ../misc/first-steps.rst:88
 msgid "Chat"
@@ -1940,7 +1940,7 @@ msgstr ""
 #: ../manage/time-accounting.rst:15
 #: ../system/integrations/checkmk/admin-panel-reference.rst:5
 msgid "Settings"
-msgstr ""
+msgstr "Impostazioni"
 
 #: ../channels/email/settings.rst:None
 msgid "Settings section in email channel"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/Admin Documentation (pre-release)](https://translations.zammad.org/projects/documentations/admin-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/admin-documentation-pre-release/horizontal-auto.svg)