### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/da/LC_MESSAGES/admin-docs.po
+++ b/locale/da/LC_MESSAGES/admin-docs.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: Zammad\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-24 09:57+0200\n"
-"PO-Revision-Date: 2026-06-10 15:12+0000\n"
-"Last-Translator: LomaxThomas <thomas.hartvig@lomax.dk>\n"
+"PO-Revision-Date: 2026-07-11 09:07+0000\n"
+"Last-Translator: Thomas Meijer <tvm@bizconnect.dk>\n"
 "Language-Team: Danish <https://translations.zammad.org/projects/"
 "documentations/admin-documentation-latest/da/>\n"
 "Language: da\n"
@@ -21,7 +21,7 @@ msgstr ""
 
 #: ../ai/ai-agents.rst:2
 msgid "AI Agents"
-msgstr ""
+msgstr "AI-agenter"
 
 #: ../ai/ai-agents.rst:4
 msgid ""
@@ -32,6 +32,12 @@ msgid ""
 "<provider>` before activating the feature. Otherwise, a warning message will "
 "tell you to do so."
 msgstr ""
+"For at hjælpe dine agenter med at fokusere på vigtigere opgaver kan du "
+"oprette AI-agenter, der kan overtage rutineopgaver. Disse AI-agenter "
+"administreres i Zammads administrationsindstillinger under *AI > AI-agenter* "
+"og kræver ``admin.ai_agent``-tilladelse. Sørg for at konfigurere en :doc:`AI "
+"provider <provider>`, inden du aktiverer funktionen. Ellers vil en "
+"advarselsbesked bede dig om det."
 
 #: ../ai/ai-agents.rst:10
 msgid ""

--- a/locale/sr/LC_MESSAGES/admin-docs.po
+++ b/locale/sr/LC_MESSAGES/admin-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad Admin Documentation pre-release\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-06-24 09:57+0200\n"
-"PO-Revision-Date: 2026-07-10 08:07+0000\n"
+"PO-Revision-Date: 2026-07-11 09:07+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
 "documentations/admin-documentation-latest/sr/>\n"
@@ -2478,8 +2478,9 @@ msgstr "Искључивање налога онемогућава и *одла�
 #: ../channels/email/accounts/managing-accounts.rst:51
 #: ../manage/calendars.rst:30 ../manage/knowledge-base.rst:159
 #: ../manage/knowledge-base.rst:187
+#, fuzzy
 msgid "Delete"
-msgstr "Избриши"
+msgstr "Obriši"
 
 #: ../channels/email/accounts/managing-accounts.rst:49
 msgid "Deleting an account removes its configuration from Zammad entirely."
@@ -16377,8 +16378,9 @@ msgstr "Овај назив ће бити приказан у оквиру из�
 
 #: ../manage/webhook/add.rst:42 ../system/integrations/cti/placetel.rst:44
 #: ../system/integrations/i-doit.rst:46
+#, fuzzy
 msgid "Endpoint"
-msgstr "Путања"
+msgstr "Endpoint"
 
 #: ../manage/webhook/add.rst:40
 msgid ""
@@ -18750,8 +18752,9 @@ msgid "How to Use it"
 msgstr "Како користити"
 
 #: ../misc/first-steps.rst:63
+#, fuzzy
 msgid "Intro"
-msgstr "Увод"
+msgstr "Uvod"
 
 #: ../misc/first-steps.rst:57
 #, fuzzy
@@ -19849,8 +19852,9 @@ msgstr ""
 "једном значком)."
 
 #: ../misc/object-conditions/basics.rst:468
+#, fuzzy
 msgid "Regex"
-msgstr "Регуларни израз"
+msgstr "Regex"
 
 #: ../misc/object-conditions/basics.rst:473
 msgid "Regex support"
@@ -35518,8 +35522,9 @@ msgstr ""
 "доступни."
 
 #: ../system/subscription.rst:189
+#, fuzzy
 msgid "Date"
-msgstr "Датум"
+msgstr "Datum"
 
 #: ../system/subscription.rst:189
 msgid "Date of the invoice creation."


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/Admin Documentation (latest)](https://translations.zammad.org/projects/documentations/admin-documentation-latest/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/admin-documentation-latest/horizontal-auto.svg)